### PR TITLE
Be specific about the tag we check.

### DIFF
--- a/src/100-cloudfoundry.conf.erb
+++ b/src/100-cloudfoundry.conf.erb
@@ -4,8 +4,9 @@ if [@type] in ["syslog", "relp"] {
 	if [@message] =~ /.*vcap.*/ {
 		grok {
 		  match => { "@message" => "%{SYSLOG5424PRI}+(?:%{TIMESTAMP_ISO8601:@shipper.timestamp}|-) +(?:%{IPORHOST:@job.host}|-) +(?:%{NOTSPACE:@shipper.name}|-) +(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) +%{GREEDYDATA:message_json}" }
+                  tag_on_failure => ["_cfparsefailure"]
 		}
-		if !("_grokparsefailure" in [tags]) {
+		if !("_cfparsefailure" in [tags]) {
 			date {
 			  match => [ "@shipper.timestamp", "ISO8601" ]
 			}

--- a/test/cfparsefailure_spec.rb
+++ b/test/cfparsefailure_spec.rb
@@ -1,0 +1,20 @@
+require "test_utils"
+require "logstash/filters/grok"
+
+describe LogStash::Filters::Grok do
+  extend LogStash::RSpec
+
+  describe "CloudFoundry message parsing failures" do
+
+    config <<-CONFIG
+      filter {
+        #{File.read("target/100-cloudfoundry.conf")}
+      }
+    CONFIG
+
+    sample("@type" => "relp", "@message" => '<14>2014-03-29T21:14:33.254640+00:00 10.0.1.13 vcap.nats - this message should fail the CF grok test') do
+      insist { subject["tags"][0]} === "_cfparsefailure"
+    end  
+  end
+
+end


### PR DESCRIPTION
To avoid other grok parsing failures from preventing the actions to follow, we should be specific about the tag we use to verify a successful parsing.
