### PR TITLE
Improve syslog support

### DIFF
--- a/src/100-cloudfoundry.conf.erb
+++ b/src/100-cloudfoundry.conf.erb
@@ -2,7 +2,7 @@
 if [@type] in ["syslog", "relp"] {
     if [@message] =~ /.*vcap.*/ {
         grok {
-            match => { "@message" => "(?:%{INT:syslog_length} )?%{SYSLOG5424PRI}(?:%{NONNEGINT:syslog5424_ver} )?+(?:%{TIMESTAMP_ISO8601:@shipper.timestamp}|-) +(?:%{IPORHOST:@job.host}|-) +(?:%{NOTSPACE:@shipper.name}|-) +(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) +%{GREEDYDATA:message}" }
+            match => { "@message" => "(?:%{INT:message_len} )?%{SYSLOG5424PRI}(?:%{NONNEGINT:syslog5424_ver} )?+(?:%{TIMESTAMP_ISO8601:@shipper.timestamp}|-) +(?:%{IPORHOST:@job.host}|-) +(?:%{NOTSPACE:@shipper.name}|-) +(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) +%{GREEDYDATA:message}" }
             add_tag => [ "cloudfoundry" ]
             tag_on_failure => ["_grokparsefailure-cloudfoundry"]
         }
@@ -55,7 +55,7 @@ if [@type] in ["syslog", "relp"] {
 
             mutate {
                 convert => [ "syslog5424_ver", "integer" ]
-                convert => [ "syslog_length", "integer" ]
+                convert => [ "message_len", "integer" ]
             }
         }	
     }	

--- a/test/cloudfoundry_spec.rb
+++ b/test/cloudfoundry_spec.rb
@@ -41,7 +41,7 @@ describe LogStash::Filters::Grok do
       insist { subject["@job.name"] } == "vcap_hm9000_listener"
       insist { subject["@job.index"] } == "0"
 
-      insist { subject["syslog_length"] } === 289
+      insist { subject["message_len"] } === 289
 
       insist { subject["log_level"] } == "info"
       insist { subject["message"] } == "Received a heartbeat - {\"Heartbeats Pending Save\":\"1\"}"


### PR DESCRIPTION
This supports better parsing of both JSON and plain text messages. It also fixes the issues where syslog prefixes the message with the message length causing them to not be parsed.

This is based on #4.
