### PR TITLE
Centos7 stemcells support

### DIFF
--- a/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -21,12 +21,17 @@ case $1 in
        echo "net.ipv6.conf.lo.disable_ipv6 = 1" >> /etc/sysctl.conf
        sysctl -p
     fi
-    
+
     echo "Waiting 1m for syslog ingestor to accept connections..."
     n=0
     until [ $n -ge 12 ]
     do
-      nc -4 -z -v <%= p("syslog.host") %> <%= p("syslog.port") %> 2>&1 && break
+      if [[ -x `which nc` ]] && nc -h 2>&1 | grep -q  -- '-z';then
+        nc -4 -z -v <%= p("syslog.host") %> <%= p("syslog.port") %> 2>&1 && break
+      else
+        (echo > /dev/tcp/<%= p("syslog.host") %>/<%= p("syslog.port") %>) > \
+          /dev/null 2>&1 && echo "OPEN" || echo "CLOSED" | grep -q OPEN && break
+      fi
       n=$[$n+1]
       echo "Waiting for syslog to accept connections ($n of 12)..."
       sleep 5


### PR DESCRIPTION
I faced the problem with updating ingestor_cloudfoundry-firehose job when I tested logsearch-for-cloudfoundry release using centos7 stemcells.

There is no –z option for ncat command in centos7. For –z we need openbsd-netcat package which was replaced with nmap-ncat in centos7.

```
nc: invalid option -- 'z'
```

Fix was tested against both Ubuntu and centos7 stemcells.