### PR TITLE
Use different indices names for application logs and CF logs.

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -1,3 +1,11 @@
+# All logs start being sent to the unparsed index.  
+# The filters below will route them to the @index=app or @index=platform
+if ! [@metadata][index] {
+    mutate {
+        add_field => { "[@metadata][index]" => "unparsed" }
+    }
+}
+
 <%= File.read('src/logstash-filters/snippets/firehose.conf') %>
 <%= File.read('src/logstash-filters/snippets/uaa.conf') %>
 
@@ -5,4 +13,3 @@
 mutate {
   remove_field => [ "@version" ]
 }
-

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -133,7 +133,8 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
     }
 
     mutate {
-      replace => { "@type" => "app" }
+      replace => { "[@metadata][index]" => "app" }
+      replace => { "[@metadata][type]" => "%{[event_type]}" }
       remove_field => "[event_type]"
       add_tag => [ 'firehose' ]
     }

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -134,7 +134,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
     mutate {
       replace => { "[@metadata][index]" => "app" }
-      replace => { "[@metadata][type]" => "%{[event_type]}" }
+      replace => { "[@type]" => "%{[event_type]}" }
       remove_field => "[event_type]"
       add_tag => [ 'firehose' ]
     }

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -65,6 +65,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
     }
 
     mutate {
+      replace => { "[@metadata][index]" => "platform" }
       replace => { "[@type]" => "uaa-audit" }
     }
   }


### PR DESCRIPTION
This is really useful to separate CF components logs from applications logs and store them in different indices.

So field [@metadata][index] is added to store index name. It is set to 'unparsed' on init. Then for application logs (those coming from firehose) we set it to 'app'. For parsed CF logs we set it to 'platform'.