### PR TITLE
Add useful parsing rules for application logs

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -211,18 +211,21 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
         # Tomcat specific parsing (in accordance with https://github.com/cloudfoundry/java-buildpack-support/blob/master/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java)
         grok {
-          match => [ "@message", "(?m)(?<log.logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:log.level}%{SPACE}%{GREEDYDATA:@message}" ]
-            overwrite => [ "@message" ]
-            tag_on_failure => [ "unknown_msg_format" ]
-          }
+          match => [ "@message", "(?m)(?<log_logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:[log][level]}%{SPACE}%{GREEDYDATA:@message}" ]
+          overwrite => [ "@message" ]
+          tag_on_failure => [ "unknown_msg_format" ]
+        }
+        mutate {
+          rename => { "log_logger" => "[log][logger]" }
+        }
 
       } else {
 
         ## ---- Format 3: Logback status logs
         grok {
-          match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:log.level} in %{NOTSPACE:log.logger} - %{GREEDYDATA:@message}" ]
-            overwrite => [ "@message" ]
-            tag_on_failure => [ "unknown_msg_format" ]
+          match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:[log][level]} in %{NOTSPACE:[log][logger]} - %{GREEDYDATA:@message}" ]
+          overwrite => [ "@message" ]
+          tag_on_failure => [ "unknown_msg_format" ]
         }
       }
 

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -7,17 +7,18 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
   if "_jsonparsefailure" in [tags] {
 
-# Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
+    # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
     mutate {
-      add_tag => ["fail/cloudfoundry/firehose/jsonparsefailure_of_syslog_message"]
-      remove_tag => ["_jsonparsefailure"]
+        add_tag => ["fail/cloudfoundry/firehose/jsonparsefailure_of_syslog_message"]
+        remove_tag => ["_jsonparsefailure"]
     }
 
   } else {
 
     date {
-      match => [ "time", "ISO8601" ]
+        match => [ "time", "ISO8601" ]
     }
+
 
     if [event_type] == "ContainerMetric" {
       mutate {
@@ -34,109 +35,114 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
       }
     }
 
+
+
     mutate {
-      rename => { "[cf_app_id]" => "[@source][app][id]" }
-      rename => { "[cf_app_name]" => "[@source][app][name]" }
-      rename => { "[cf_space_id]" => "[@source][space][id]" }
-      rename => { "[cf_space_name]" => "[@source][space][name]" }
-      rename => { "[cf_org_id]" => "[@source][org][id]" }
-      rename => { "[cf_org_name]" => "[@source][org][name]" }
+        rename => { "[cf_app_id]" => "[@source][app][id]" }
+        rename => { "[cf_app_name]" => "[@source][app][name]" }
+        rename => { "[cf_space_id]" => "[@source][space][id]" }
+        rename => { "[cf_space_name]" => "[@source][space][name]" }
+        rename => { "[cf_org_id]" => "[@source][org][id]" }
+        rename => { "[cf_org_name]" => "[@source][org][name]" }
 
-      rename => { "[level]" => "[@level]" }
-      uppercase => [ "[@level]" ]
+        rename => { "[level]" => "[@level]" }
+        uppercase => [ "[@level]" ]
 
-      rename => { "[host]" => "[@source][host]" }
-      rename => { "[source_type]" => "[@source][component]" }
-      rename => { "[source_instance]" => "[@source][instance]" }
-      add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
-      convert => { "[@source][instance]" => "integer" }
+        rename => { "[host]" => "[@source][host]" }
+        rename => { "[source_type]" => "[@source][component]" }
+        rename => { "[source_instance]" => "[@source][instance]" }
+        add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
+        convert => { "[@source][instance]" => "integer" }
 
-      rename => { "[message_type]" => "[@source][message_type]" }
-      rename => { "[origin]" => "[@source][origin]" }
+        rename => { "[message_type]" => "[@source][message_type]" }
+        rename => { "[origin]" => "[@source][origin]" }
 
-      rename => { "[msg]" => "[@message]" }
+        rename => { "[msg]" => "[@message]" }
     }
 
-# Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
+    # Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
     mutate {
       gsub => [ "[@message]", '\u2028', "
-"]
+"
+      ]
     }
 
     if ('RTR' in [@source][component]) {
-      grok {
+        grok {
 
-#cf-release > v222 - includes x_forwarded_proto
-      match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[RTR][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+            #cf-release > v222 - includes x_forwarded_proto
+            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[RTR][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
 
-#cf-release > v205 - includes RequestBytesReceived
-      match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+            #cf-release > v205 - includes RequestBytesReceived
+            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
 
-#cf-release <= v205
-      match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
-        overwrite => [ "time" ]
-        tag_on_failure => [ 'fail/firehose/RTR' ]
-        add_tag => "RTR"
-      }
-
-      if !("fail/firehose/RTR" in [tags]) {
-        date {
-          match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
+            #cf-release <= v205
+            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+            overwrite => [ "time" ]
+            tag_on_failure => [ 'fail/firehose/RTR' ]
+            add_tag => "RTR"
         }
 
-        # set @level based on HTTP status
-        if [RTR][status] >= 400 {
-          mutate {
-            replace => { "[@level]" => "ERROR" }
-          }
-        }
-
-        if [RTR][x_forwarded_for] {
-          mutate {
-            gsub => ["[RTR][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
-            split => ["[RTR][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
-          }
-
-          ruby {
-            code => "event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int"
-            remove_field => "response_time_sec"
-          }
-
-          mutate {
-            add_field => ["[RTR][remote_addr]", "%{[RTR][x_forwarded_for][0]}"]
-          }
-
-          if ([RTR][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
-            geoip {
-              source => "[RTR][remote_addr]"
+        if !("fail/firehose/RTR" in [tags]) {
+            date {
+                match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
             }
-          }
+
+            # set @level based on HTTP status
+            if [RTR][status] >= 400 {
+              mutate {
+                replace => { "[@level]" => "ERROR" }
+              }
+            }
+
+
+            if [RTR][x_forwarded_for] {
+                mutate {
+                    gsub => ["[RTR][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
+                    split => ["[RTR][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
+                }
+
+               ruby {
+                   code => "event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int"
+                   remove_field => "response_time_sec"
+               }
+
+               mutate {
+                  add_field => ["[RTR][remote_addr]", "%{[RTR][x_forwarded_for][0]}"]
+               }
+
+               if ([RTR][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
+                   geoip {
+                     source => "[RTR][remote_addr]"
+                   }
+               }
+            }
         }
-      }
     }
 
-# Cleanup unused fields
+    # Cleanup unused fields
     mutate {
-      remove_field => "time"
-      remove_field => "timestamp"
-      remove_field => "received_from"
-      remove_field => "received_at"
-      remove_field => "syslog_severity_code"
-      remove_field => "syslog_facility_code"
-      remove_field => "syslog_facility"
-      remove_field => "syslog_severity"
-      remove_field => "syslog_pri"
-      remove_field => "syslog_program"
-      remove_field => "syslog_pid"
-      remove_field => "syslog_hostname"
-      remove_field => "syslog_timestamp"
+        remove_field => "time"
+        remove_field => "timestamp"
+        remove_field => "received_from"
+        remove_field => "received_at"
+        remove_field => "syslog_severity_code"
+        remove_field => "syslog_facility_code"
+        remove_field => "syslog_facility"
+        remove_field => "syslog_severity"
+        remove_field => "syslog_pri"
+        remove_field => "syslog_program"
+        remove_field => "syslog_pid"
+        remove_field => "syslog_hostname"
+        remove_field => "syslog_timestamp"
     }
 
+    #Route to index and type
     mutate {
-      replace => { "[@metadata][index]" => "app" }
-      replace => { "[@type]" => "%{[event_type]}" }
-      remove_field => "[event_type]"
-      add_tag => [ 'firehose' ]
+        replace => { "[@metadata][index]" => "app" }
+        replace => { "[@type]" => "%{[event_type]}" }
+        remove_field => "[event_type]"
+        add_tag => [ 'firehose' ]
     }
     
     ## -------------- App Specific Parsing Start --------------- ##
@@ -231,6 +237,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
     }
     ## -------------- App Specific Parsing End --------------- ##
-    
+
   }
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -19,6 +19,12 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         match => [ "time", "ISO8601" ]
     }
 
+    # Ensure that we always have an event_type
+    if ![event_type] {
+        mutate {
+            add_field => [ "event_type", "LogMessage" ]
+        }
+    }
 
     if [event_type] == "ContainerMetric" {
       mutate {
@@ -89,10 +95,14 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
             }
 
             # set @level based on HTTP status
-            if [RTR][status] >= 400 {
-              mutate {
-                replace => { "[@level]" => "ERROR" }
-              }
+            if [RTR][status] >= 500 {
+                mutate {
+                    replace => { "[@level]" => "ERROR" }
+                }
+            } else if [RTR][status] >= 400 {
+                mutate {
+                    replace => { "[@level]" => "WARN" }
+                }
             }
 
 

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -138,5 +138,99 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
       remove_field => "[event_type]"
       add_tag => [ 'firehose' ]
     }
+    
+    ## -------------- App Specific Parsing Start --------------- ##
+    # Set index name for app logs
+    mutate { replace => [ "[@metadata][index]", "app-%{[@source][org][name]}-%{[@source][space][name]}" ] }
+    mutate { lowercase => [ "[@metadata][index]" ] }
+
+    # Parse App logs based on msg format (mark unknown format with [unknown_msg_format] tag)
+    if( [@source][component] == "App" ) {
+      ## App logs
+
+      ## ---- Format 1: JSON
+      # check if it is JSON
+      if [@message] =~ /^\s*{".*}\s*$/ {
+
+        json {
+          source => '@message'
+          target => 'log'
+        }
+
+        if "_jsonparsefailure" in [tags] {
+
+          mutate {
+            add_tag => ["unknown_msg_format"]
+            remove_tag => ["_jsonparsefailure"]
+          }
+        } else {
+
+          # set date from json log timestamp
+          date {
+            match => [ "[log][timestamp]", "ISO8601" ]
+            add_tag => ["log_timestamp"]
+          }
+
+          # concat message and exception
+          if ( [log][exception] ) {
+
+            mutate {
+              ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
+              replace => [ "@message", "%{[log][message]}
+%{[log][exception]}" ]
+              remove_field => [ "[log][message]", "[log][exception]" ]
+            }
+          } else {
+
+            mutate {
+              rename => { "[log][message]" => "[@message]" }
+            }
+          }
+
+        }
+
+      } else if [@message] =~ /^\[CONTAINER\]/ {
+
+        ## ---- Format 2: "[CONTAINER] .." (Tomcat logs)
+
+        # Tomcat specific parsing (in accordance with https://github.com/cloudfoundry/java-buildpack-support/blob/master/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java)
+        grok {
+          match => [ "@message", "(?m)(?<log.logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:log.level}%{SPACE}%{GREEDYDATA:@message}" ]
+            overwrite => [ "@message" ]
+            tag_on_failure => [ "unknown_msg_format" ]
+          }
+
+      } else {
+
+        ## ---- Format 3: Logback status logs
+        grok {
+          match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:log.level} in %{NOTSPACE:log.logger} - %{GREEDYDATA:@message}" ]
+            overwrite => [ "@message" ]
+            tag_on_failure => [ "unknown_msg_format" ]
+        }
+      }
+
+      if( "log_timestamp" not in [tags] ) {
+
+        # set date from syslog time
+        date {
+          match => [ "time", "ISO8601" ]
+        }
+      }
+
+      if ( [log][level] ) {
+        mutate {
+          rename => { "[log][level]" => "[@level]" }
+          uppercase => [ "[@level]" ]
+        }
+      }
+
+
+      # remove temporary tag
+      mutate { remove_tag => ["log_timestamp"] }
+
+    }
+    ## -------------- App Specific Parsing End --------------- ##
+    
   }
 }


### PR DESCRIPTION
This PR includes improvements made for application logs parsing (firehose.conf). The changes are described below. Please note that it is better to review the changes made in each commit rather than altogether because there were changes in formatting so the diff shows them in a not really convenient way.

The changes are the following:

Store application logs from different CF organizations / spaces to different indices (index name is defined by organization & space name). 
So app index name format is the following: app-${org}-${space}.

The PR includes parsing rules for JSON logs, Tomcat ([CONTAINER]) logs and Logback status logs.

And there are some minor fixes for application logs parsing: add event_type field if it is not passed, improve calculation of RTR logs level based on HTTP status, improve formatting.