### PR TITLE
Add parsing rules for haproxy

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -7,6 +7,7 @@ if ! [@metadata][index] {
 }
 
 <%= File.read('src/logstash-filters/snippets/firehose.conf') %>
+<%= File.read('src/logstash-filters/snippets/haproxy.conf') %>
 <%= File.read('src/logstash-filters/snippets/uaa.conf') %>
 
 #Cleanup

--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -1,0 +1,80 @@
+if [@type] in ["syslog", "relp"] and [syslog_program] == "haproxy" {
+
+    grok {
+      match => [ "@message", "(?:\[job=%{NOTSPACE:jobname}|-) +(?:index=%{NOTSPACE:jobindex}\]|-)%{SPACE}%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]} %{NOTSPACE:[haproxy][backend_name]}/%{NOTSPACE:[haproxy][server_name]} %{INT:[haproxy][time_request]}/%{INT:[haproxy][time_queue]}/%{INT:[haproxy][time_backend_connect]}/%{INT:[haproxy][time_backend_response]}/%{NOTSPACE:[haproxy][time_duration]} %{INT:[haproxy][http_status_code]} %{NOTSPACE:[haproxy][bytes_read]} %{DATA:[haproxy][captured_request_cookie]} %{DATA:[haproxy][captured_response_cookie]} %{NOTSPACE:[haproxy][termination_state]} %{INT:[haproxy][actconn]}/%{INT:[haproxy][feconn]}/%{INT:[haproxy][beconn]}/%{INT:[haproxy][srvconn]}/%{NOTSPACE:[haproxy][retries]} %{INT:[haproxy][srv_queue]}/%{INT:[haproxy][backend_queue]} (%{GREEDYDATA:[haproxy][headers]})?( )?\"(?<message>(<BADREQ>|(%{WORD:[haproxy][http_verb]} (%{URIPROTO:[haproxy][http_proto]}://)?(?:%{USER:[haproxy][http_user]}(?::[^@]*)?@)?(?:%{URIHOST:[haproxy][http_host]})?(?:%{URIPATHPARAM:[haproxy][http_request]})?( HTTP/%{NUMBER:[haproxy][http_version]})?))?)\"" ]
+      tag_on_failure => "fail/cloudfoundry/haproxy/grok"
+    }
+
+    if !("fail/cloudfoundry/haproxy/grok" in [tags]) {
+
+      # ------------ specific fields ----------------
+      if [haproxy][accept_date] { # date
+        date {
+          match => [ "[haproxy][accept_date]", "dd/MMM/YYYY:HH:mm:ss.SSS" ]
+          remove_field => [ "[haproxy][accept_date]" ]
+        }
+      }
+
+      mutate {
+        rename => {"message" => "@message"} # @message
+      }
+
+      mutate {  # @level
+        convert => { "[haproxy][http_status_code]" => "integer" }
+      }
+      if [haproxy][http_status_code] >= 400 {
+        mutate {
+          add_field => { "@level" => "ERROR" }
+        }
+      } else {
+        mutate {
+          add_field => { "@level" => "INFO" }
+        }
+      }
+
+      # ------------- common fields ------------------
+
+      # @source (component, name, instance, host) & @shipper
+      mutate {
+        add_field => { "[@source][component]" => "haproxy" } # specific value
+        add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
+      }
+      mutate {
+        convert => { "jobindex" => "integer" }
+      }
+      mutate {
+        rename => { "jobindex" => "[@source][instance]" }
+        remove_field => "jobname"
+        replace => [ "[@job][host]", "%{[@source][host]}" ]
+      }
+
+      # @shipper
+      mutate {
+        replace => [ "[@shipper][priority]", "%{syslog_pri}" ]
+        replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
+      }
+
+      # remove syslog_ fields
+      mutate {      
+        remove_field => "syslog_pri"
+        remove_field => "syslog_facility"
+        remove_field => "syslog_facility_code"
+        remove_field => "syslog_message"
+        remove_field => "syslog_severity"
+        remove_field => "syslog_severity_code"
+        remove_field => "syslog_program"
+        remove_field => "syslog_timestamp"
+        remove_field => "syslog_hostname"
+      }
+
+      # -------- specific index & type, tags ----------
+      mutate {
+        replace => { "[@metadata][index]" => "platform" }
+        replace => { "[@type]" => "haproxy_cf" }
+        add_tag => "haproxy-cf"
+      }
+      # -----------------------------------------------
+
+    }
+
+}


### PR DESCRIPTION
This PR adds parsing rules for haproxy job logs.

Haproxy is usually deployed with CF so it is useful to have it logs parsed.