### PR TITLE
Add parsing rules for CF components (vcap) logs.

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -8,6 +8,7 @@ if ! [@metadata][index] {
 
 <%= File.read('src/logstash-filters/snippets/firehose.conf') %>
 <%= File.read('src/logstash-filters/snippets/uaa.conf') %>
+<%= File.read('src/logstash-filters/snippets/vcap.conf') %>
 
 #Cleanup
 mutate {

--- a/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
@@ -1,0 +1,82 @@
+if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
+
+    # Parse logs from Cloud Foundry components (vcap). Note that UAA logs are handled by rules in uaa.conf snippet.
+
+    grok {
+        match => { "@message" => "(?:\[job=%{NOTSPACE:jobname}|-) +(?:index=%{NOTSPACE:jobindex}\]|-)%{SPACE}%{GREEDYDATA:@message}" }
+        overwrite => [ "@message" ] # @message
+        tag_on_failure => "fail/cloudfoundry/vcap/grok"
+    }
+
+    if !("fail/cloudfoundry/vcap/grok" in [tags]) {
+
+        # -------- message additional parsing & specific fields ----------
+
+        # JSON parsing
+        if [@message] =~ /^\{/ {
+            
+            json {
+              source => "@message"
+              target => "vcap"
+              remove_field => [ "@message" ]
+            }
+
+            mutate {
+              convert => { "[vcap][log_level]" => "string" }
+            }
+            mutate {
+              rename => { "[vcap][log_level]" => "[@level]" } # @level
+            }
+            mutate {
+              rename => { "[vcap][message]" => "[@message]" } # @message
+            }
+
+        }
+
+        # ------------- common fields ------------------
+
+        # @source (component, name, instance, host) & @shipper
+        ruby {
+          code => "event['[@source][component]'] = event['syslog_program'][5..-1]" # minus "vcap." prefix
+        }
+        mutate {
+          add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
+        }
+        mutate {
+          convert => { "jobindex" => "integer" }
+        }
+        mutate {
+          rename => { "jobindex" => "[@source][instance]" }
+          remove_field => "jobname"
+          replace => [ "[@job][host]", "%{[@source][host]}" ]
+        }
+
+        # @shipper
+        mutate {
+            replace => [ "[@shipper][priority]", "%{syslog_pri}" ]
+            replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
+        }
+
+        # remove syslog_ fields
+        mutate {      
+          remove_field => "syslog_pri"
+          remove_field => "syslog_facility"
+          remove_field => "syslog_facility_code"
+          remove_field => "syslog_message"
+          remove_field => "syslog_severity"
+          remove_field => "syslog_severity_code"
+          remove_field => "syslog_program"
+          remove_field => "syslog_timestamp"
+          remove_field => "syslog_hostname"
+        }
+
+        # --------- specific index & type, tags -----------
+        mutate {
+          replace => { "[@metadata][index]" => "platform" }
+          replace => { "[@type]" => "vcap_cf" }
+          add_tag => "vcap-cf"
+        }
+        # --------------------------------------------------
+    }
+
+}


### PR DESCRIPTION
General parsing rules for CF components' logs (vcap).

Additionally a vcap log is parsed as json (if in json format) and json properties are stored to vcap.* fields.