### PR TITLE
Filters refactoring & rework

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -1,17 +1,25 @@
-# All logs start being sent to the unparsed index.  
-# The filters below will route them to the @index=app or @index=platform
+# Index
 if ! [@metadata][index] {
+    # All logs start being sent to the unparsed index. The filters below will route them to the @index=app* or @index=platform.
     mutate {
         add_field => { "[@metadata][index]" => "unparsed" }
     }
 }
 
+# Include snippets
+
 <%= File.read('src/logstash-filters/snippets/firehose.conf') %>
+
 <%= File.read('src/logstash-filters/snippets/haproxy.conf') %>
+
 <%= File.read('src/logstash-filters/snippets/uaa.conf') %>
+
 <%= File.read('src/logstash-filters/snippets/vcap.conf') %>
 
-#Cleanup
+
+# Cleanup
 mutate {
+  rename => { "[tags]" => "[@tags]" }
+  uppercase => [ "[@level]" ]
   remove_field => [ "@version" ]
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -1,255 +1,263 @@
-# Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)
 if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
-  json {
-    source => '@message'
-  }
+    # Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)
 
-  if "_jsonparsefailure" in [tags] {
-
-    # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
-    mutate {
-        add_tag => ["fail/cloudfoundry/firehose/jsonparsefailure_of_syslog_message"]
-        remove_tag => ["_jsonparsefailure"]
+    json {
+      source => '@message'
     }
 
-  } else {
+    if "_jsonparsefailure" in [tags] {
 
-    date {
-        match => [ "time", "ISO8601" ]
-    }
-
-    # Ensure that we always have an event_type
-    if ![event_type] {
+        # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
         mutate {
-            add_field => [ "event_type", "LogMessage" ]
-        }
-    }
-
-    if [event_type] == "ContainerMetric" {
-      mutate {
-        add_tag => "ContainerMetric"
-        add_field => {"[@source][component]" => "METRIC"}
-        add_field => {"[@source][instance]" => "%{[instance_index]}"}
-      }
-
-      mutate {
-        rename => { "[cpu_percentage]" => "[container][cpu_percentage]" }
-        rename => { "[memory_bytes]" => "[container][memory_bytes]" }
-        rename => { "[disk_bytes]" => "[container][disk_bytes]" }
-        remove => "[instance_index]"
-      }
-    }
-
-
-
-    mutate {
-        rename => { "[cf_app_id]" => "[@source][app][id]" }
-        rename => { "[cf_app_name]" => "[@source][app][name]" }
-        rename => { "[cf_space_id]" => "[@source][space][id]" }
-        rename => { "[cf_space_name]" => "[@source][space][name]" }
-        rename => { "[cf_org_id]" => "[@source][org][id]" }
-        rename => { "[cf_org_name]" => "[@source][org][name]" }
-
-        rename => { "[level]" => "[@level]" }
-        uppercase => [ "[@level]" ]
-
-        rename => { "[host]" => "[@source][host]" }
-        rename => { "[source_type]" => "[@source][component]" }
-        rename => { "[source_instance]" => "[@source][instance]" }
-        add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
-        convert => { "[@source][instance]" => "integer" }
-
-        rename => { "[message_type]" => "[@source][message_type]" }
-        rename => { "[origin]" => "[@source][origin]" }
-
-        rename => { "[msg]" => "[@message]" }
-    }
-
-    # Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
-    mutate {
-      gsub => [ "[@message]", '\u2028', "
-"
-      ]
-    }
-
-    if ('RTR' in [@source][component]) {
-        grok {
-
-            #cf-release > v222 - includes x_forwarded_proto
-            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[RTR][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
-
-            #cf-release > v205 - includes RequestBytesReceived
-            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
-
-            #cf-release <= v205
-            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
-            overwrite => [ "time" ]
-            tag_on_failure => [ 'fail/firehose/RTR' ]
-            add_tag => "RTR"
-        }
-
-        if !("fail/firehose/RTR" in [tags]) {
-            date {
-                match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
-            }
-
-            # set @level based on HTTP status
-            if [RTR][status] >= 500 {
-                mutate {
-                    replace => { "[@level]" => "ERROR" }
-                }
-            } else if [RTR][status] >= 400 {
-                mutate {
-                    replace => { "[@level]" => "WARN" }
-                }
-            }
-
-
-            if [RTR][x_forwarded_for] {
-                mutate {
-                    gsub => ["[RTR][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
-                    split => ["[RTR][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
-                }
-
-               ruby {
-                   code => "event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int"
-                   remove_field => "response_time_sec"
-               }
-
-               mutate {
-                  add_field => ["[RTR][remote_addr]", "%{[RTR][x_forwarded_for][0]}"]
-               }
-
-               if ([RTR][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
-                   geoip {
-                     source => "[RTR][remote_addr]"
-                   }
-               }
-            }
-        }
-    }
-
-    # Cleanup unused fields
-    mutate {
-        remove_field => "time"
-        remove_field => "timestamp"
-        remove_field => "received_from"
-        remove_field => "received_at"
-        remove_field => "syslog_severity_code"
-        remove_field => "syslog_facility_code"
-        remove_field => "syslog_facility"
-        remove_field => "syslog_severity"
-        remove_field => "syslog_pri"
-        remove_field => "syslog_program"
-        remove_field => "syslog_pid"
-        remove_field => "syslog_hostname"
-        remove_field => "syslog_timestamp"
-    }
-
-    #Route to index and type
-    mutate {
-        replace => { "[@metadata][index]" => "app" }
-        replace => { "[@type]" => "%{[event_type]}" }
-        remove_field => "[event_type]"
-        add_tag => [ 'firehose' ]
-    }
-    
-    ## -------------- App Specific Parsing Start --------------- ##
-    # Set index name for app logs
-    mutate { replace => [ "[@metadata][index]", "app-%{[@source][org][name]}-%{[@source][space][name]}" ] }
-    mutate { lowercase => [ "[@metadata][index]" ] }
-
-    # Parse App logs based on msg format (mark unknown format with [unknown_msg_format] tag)
-    if( [@source][component] == "App" ) {
-      ## App logs
-
-      ## ---- Format 1: JSON
-      # check if it is JSON
-      if [@message] =~ /^\s*{".*}\s*$/ {
-
-        json {
-          source => '@message'
-          target => 'log'
-        }
-
-        if "_jsonparsefailure" in [tags] {
-
-          mutate {
-            add_tag => ["unknown_msg_format"]
+            add_tag => ["fail/cloudfoundry/firehose/jsonparsefailure_of_syslog_message"]
             remove_tag => ["_jsonparsefailure"]
-          }
-        } else {
+        }
 
-          # set date from json log timestamp
-          date {
-            match => [ "[log][timestamp]", "ISO8601" ]
-            add_tag => ["log_timestamp"]
-          }
+    } else {
 
-          # concat message and exception
-          if ( [log][exception] ) {
+        # -------- message additional parsing ----------
 
+        # by default all logs should have event_type LogMessage
+        if ![event_type] {
             mutate {
-              ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
-              replace => [ "@message", "%{[log][message]}
-%{[log][exception]}" ]
-              remove_field => [ "[log][message]", "[log][exception]" ]
+                add_field => [ "event_type", "LogMessage" ] 
             }
+        }
+
+        # app @source
+        mutate {
+            rename => { "[cf_org_id]"     => "[@source][org][id]" }
+            rename => { "[cf_org_name]"   => "[@source][org][name]" }
+            rename => { "[cf_space_id]"   => "[@source][space][id]" }
+            rename => { "[cf_space_name]" => "[@source][space][name]" }
+            rename => { "[cf_app_id]"     => "[@source][app][id]" }
+            rename => { "[cf_app_name]"   => "[@source][app][name]" }
+            
+            rename => { "[origin]"        => "[@source][origin]" } # CF logging component        
+            rename => { "[message_type]"  => "[@source][message_type]" } # OUT/ ERR
+        }
+
+        # Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
+        mutate {
+          gsub => [ "[msg]", '\u2028', "
+"
+          ]
+        } 
+        # Replace the unicode Null character \u0000 with \n
+        mutate {
+          gsub => [ "[msg]", '\u0000', ""]
+        }
+        # Ignore logs with empty msg
+        if [msg] =~ /^\s*$/ or [msg] =~ /^#.*$/ {
+          drop { }
+        }
+
+        # ------------ specific fields ----------------
+        date {
+            match => [ "time", "ISO8601" ] # date
+        }
+
+        mutate {
+            rename => { "[msg]" => "[@message]" } # @message
+            rename => { "[level]" => "[@level]" } # @level
+        }
+
+        # ------------- common fields ------------------
+
+        # @source (component, name, instance, host) & @shipper
+        mutate {
+          rename => { "[host]" => "[@source][host]" }
+          rename => { "[source_type]" => "[@source][component]" }
+          rename => { "[source_instance]" => "[@source][instance]" }
+          add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
+          convert => { "[@source][instance]" => "integer" }
+        }
+
+        # @shipper
+        mutate {
+          replace => [ "[@shipper][priority]", "%{syslog_pri}" ]
+          replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
+        }
+
+        # remove syslog_ fields and unnecessary fields
+        mutate {
+            remove_field => "syslog_severity_code"
+            remove_field => "syslog_facility_code"
+            remove_field => "syslog_facility"
+            remove_field => "syslog_severity"
+            remove_field => "syslog_pri"
+            remove_field => "syslog_program"
+            remove_field => "syslog_pid"
+            remove_field => "syslog_hostname"
+            remove_field => "syslog_timestamp"
+
+            remove_field => "time"
+            remove_field => "timestamp"
+            remove_field => "received_from"
+            remove_field => "received_at"
+        }
+        
+        # --------- specific index & type, tags -----------
+        mutate { replace => [ "[@metadata][index]", "app-%{[@source][org][name]}-%{[@source][space][name]}" ] } # custom index name
+        mutate { lowercase => [ "[@metadata][index]" ] }
+
+        mutate {
+            replace => { "[@type]" => "%{[event_type]}" }
+            remove_field => "[event_type]"
+            add_tag => [ 'firehose' ]
+        }
+        # ----------- special cases processing -------------
+        # ----------------------------
+        # Special Case - Metrics logs |
+        # ----------------------------
+        if( [@type] == "ContainerMetric" ) {
+          mutate {
+            add_tag => "ContainerMetric"
+            replace => {"[@source][component]" => "METRIC"}
+            replace => {"[@source][instance]" => "%{[instance_index]}"}
+          }
+          mutate {
+            rename => { "[cpu_percentage]" => "[container][cpu_percentage]" }
+            rename => { "[memory_bytes]" => "[container][memory_bytes]" }
+            rename => { "[disk_bytes]" => "[container][disk_bytes]" }
+            remove_field => "[instance_index]"
+          }
+        }
+
+        # ------------------------
+        # Special Case - RTR logs |
+        # ------------------------
+        if ('RTR' in [@source][component]) {
+            grok {
+
+                #cf-release > v222 - includes x_forwarded_proto
+                match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[RTR][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                
+                #cf-release > v205 - includes RequestBytesReceived
+                match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                
+                #cf-release <= v205
+                match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                overwrite => [ "time" ]
+                tag_on_failure => [ 'fail/firehose/RTR' ]
+                add_tag => "RTR"
+            }
+
+            if !("fail/firehose/RTR" in [tags]) {
+                date {
+                    match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
+                }
+
+                # set @level based on HTTP status
+                if [RTR][status] >= 400 {
+                    mutate {
+                        replace => { "[@level]" => "ERROR" } # @level
+                    }
+                }
+
+                if [RTR][x_forwarded_for] {
+                    mutate {
+                        gsub => ["[RTR][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
+                        split => ["[RTR][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
+                    }
+
+                   ruby {
+                       code => "event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int"
+                       remove_field => "response_time_sec"
+                   }
+
+                   mutate {
+                      add_field => ["[RTR][remote_addr]", "%{[RTR][x_forwarded_for][0]}"]
+                   }
+
+                   if ([RTR][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
+                       geoip {
+                         source => "[RTR][remote_addr]"
+                       }
+                   }
+                }
+            }
+        }
+
+        ## -------------- Custom Config Start --------------- ##
+        # ------------------------
+        # Special Case - App logs |
+        # ------------------------
+        # Parse App logs based on msg format (mark unknown format with [unknown_msg_format] tag)
+        if( [@source][component] == "App" ) {
+
+          ## ---- Format 1: JSON
+          # check if it is JSON
+          if [@message] =~ /^\s*{".*}\s*$/ {
+          
+            json {
+              source => '@message'
+              target => 'log'
+            }
+
+            if !("_jsonparsefailure" in [tags]) {
+
+              date {
+                match => [ "[log][timestamp]", "ISO8601" ] # date
+              }
+
+              # conacat message and exception
+              if ( [log][exception] ) {
+
+                mutate {
+                  ## NOTE: keep line break and new line spacing (new line is inserted in logstash in such a way)
+                  replace => [ "@message", "%{[log][message]}
+%{[log][exception]}" ]
+                  remove_field => [ "[log][message]", "[log][exception]" ]
+                }
+              } else {
+
+                mutate {
+                  rename => { "[log][message]" => "[@message]" }
+                }
+              }
+
+            } else {
+
+              mutate {
+                add_tag => ["unknown_msg_format"]
+                remove_tag => ["_jsonparsefailure"]
+              }
+            } 
+
+          ## ---- Format 2: "[CONTAINER] .." (Tomcat logs)
+         } else if [@message] =~ /^\s*\[CONTAINER\]/ {
+
+            # Tomcat specific parsing (in accordance with https://github.com/cloudfoundry/java-buildpack-support/blob/master/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java)
+            grok {
+              match => [ "@message", "(?m)(?<log_logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:[log][level]}%{SPACE}%{GREEDYDATA:@message}" ]
+              overwrite => [ "@message" ]
+              tag_on_failure => [ "unknown_msg_format" ]
+            }
+            mutate {
+              rename => { "log_logger" => "[log][logger]" }
+            }
+
           } else {
 
-            mutate {
-              rename => { "[log][message]" => "[@message]" }
+            ## ---- Format 3: Logback status logs
+            grok {
+              match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:[log][level]} in %{NOTSPACE:[log][logger]} - %{GREEDYDATA:@message}" ]
+              overwrite => [ "@message" ]
+
+            ## ---- Unknown Format: otherwise set with 'unknown_msg_format' tag
+              tag_on_failure => [ "unknown_msg_format" ]
             }
           }
 
+          mutate {
+            rename => { "[log][level]" => "[@level]" } # @level
+          }
+
         }
-
-      } else if [@message] =~ /^\[CONTAINER\]/ {
-
-        ## ---- Format 2: "[CONTAINER] .." (Tomcat logs)
-
-        # Tomcat specific parsing (in accordance with https://github.com/cloudfoundry/java-buildpack-support/blob/master/tomcat-logging-support/src/main/java/com/gopivotal/cloudfoundry/tomcat/logging/CloudFoundryFormatter.java)
-        grok {
-          match => [ "@message", "(?m)(?<log_logger>\[CONTAINER\]%{SPACE}%{NOTSPACE})%{SPACE}%{LOGLEVEL:[log][level]}%{SPACE}%{GREEDYDATA:@message}" ]
-          overwrite => [ "@message" ]
-          tag_on_failure => [ "unknown_msg_format" ]
-        }
-        mutate {
-          rename => { "log_logger" => "[log][logger]" }
-        }
-
-      } else {
-
-        ## ---- Format 3: Logback status logs
-        grok {
-          match => [ "@message", "%{TIME} \|\-%{LOGLEVEL:[log][level]} in %{NOTSPACE:[log][logger]} - %{GREEDYDATA:@message}" ]
-          overwrite => [ "@message" ]
-          tag_on_failure => [ "unknown_msg_format" ]
-        }
-      }
-
-      if( "log_timestamp" not in [tags] ) {
-
-        # set date from syslog time
-        date {
-          match => [ "time", "ISO8601" ]
-        }
-      }
-
-      if ( [log][level] ) {
-        mutate {
-          rename => { "[log][level]" => "[@level]" }
-          uppercase => [ "[@level]" ]
-        }
-      }
-
-
-      # remove temporary tag
-      mutate { remove_tag => ["log_timestamp"] }
+        ## -------------- Custom Config End --------------- ##
 
     }
-    ## -------------- App Specific Parsing End --------------- ##
 
-  }
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -1,72 +1,99 @@
 if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
-  grok {
-    match => { "@message" => "\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]"
-    }
-    tag_on_failure => ["fail/cloudfoundry/uaa-audit"]
-    add_tag => "uaa-audit"
-  }
 
-  if !("fail/cloudfoundry/uaa-audit" in [tags]) {
-    date {
-      match => [ "uaa_timestamp", "ISO8601" ]
-      remove_field => "uaa_timestamp"
+    grok {
+        match => { "@message" =>
+        "\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\]%{SPACE}\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]"
+        }
+        tag_on_failure => [
+            "fail/cloudfoundry/uaa"
+        ]
+        remove_field => [ "@message" ]
     }
 
-    if "PrincipalAuthenticationFailure" == [audit_event_type] {
-      mutate {
-        add_field => { "audit_event_remote_address" => "%{audit_event_origin}" }
-      }
+    if !("fail/cloudfoundry/uaa" in [tags]) {
+
+        # ------------ specific fields ----------------
+        date {
+            match => [ "uaa_timestamp", "ISO8601" ]
+            remove_field => "uaa_timestamp"
+        }
+        mutate {
+          rename => { "loglevel" => "[@level]" } # @level
+        }
+
+        # UAA specific
+        if "PrincipalAuthenticationFailure" == [audit_event_type] {
+            mutate {
+                add_field => { "audit_event_remote_address" => "%{audit_event_origin}" }
+           }
+        }
+        if [audit_event_origin] =~ /remoteAddress=/ {
+            grok {
+                match => { "audit_event_origin" => "remoteAddress=%{IP:audit_event_remote_address}" }
+            }
+        }
+        if [audit_event_remote_address] {
+           geoip {
+              source => "audit_event_remote_address"
+           }
+        }
+        mutate {
+            split =>  { "audit_event_origin" => ", " }
+        }
+        mutate {
+            rename => { "pid"            => "[uaa][pid]" }
+            rename => { "thread_name"     => "[uaa][thread_name]" }
+            rename => { "audit_event_type"              => "[uaa][type]" }
+            rename => { "audit_event_remote_address"    => "[uaa][remote_address]" }
+            rename => { "audit_event_data"              => "[uaa][data]" }
+            rename => { "audit_event_principal"         => "[uaa][principal]" }
+            rename => { "audit_event_origin"            => "[uaa][origin]" }
+            rename => { "audit_event_identity_zone_id"  => "[uaa][identity_zone_id]" }
+        }
+
+        # ------------- common fields ------------------
+
+        # @source (component, name, instance, host) & @shipper
+        mutate {
+          add_field => { "[@source][component]" => "uaa" } # specific value
+          add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
+        }
+        mutate {
+          convert => { "jobindex" => "integer" }
+        }
+        mutate {
+          rename => { "jobindex" => "[@source][instance]" }
+          remove_field => "jobname"
+          replace => [ "[@job][host]", "%{[@source][host]}" ]
+        }
+
+        # @shipper
+        mutate {
+            replace => [ "[@shipper][priority]", "%{syslog_pri}" ]
+            replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
+        }
+
+        # remove syslog_ fields
+        mutate {      
+          remove_field => "syslog_pri"
+          remove_field => "syslog_facility"
+          remove_field => "syslog_facility_code"
+          remove_field => "syslog_message"
+          remove_field => "syslog_severity"
+          remove_field => "syslog_severity_code"
+          remove_field => "syslog_program"
+          remove_field => "syslog_timestamp"
+          remove_field => "syslog_hostname"
+        }
+
+        # -------- specific index & type, tags ----------
+        mutate {
+          replace => { "[@metadata][index]" => "platform" }
+          replace => { "[@type]" => "uaa_cf" }
+          add_tag => "uaa-cf"
+        }
+        # -----------------------------------------------
     }
 
-    if [audit_event_origin] =~ /remoteAddress=/ {
-      grok {
-        match => { "audit_event_origin" => "remoteAddress=%{IP:audit_event_remote_address}" }
-      }
-    }
-
-    if [audit_event_remote_address] {
-      geoip {
-        source => "audit_event_remote_address"
-      }
-    }
-
-    mutate {
-      remove_field => "syslog_pri"
-      remove_field => "syslog_facility"
-      remove_field => "syslog_facility_code"
-      remove_field => "@message"
-      remove_field => "syslog_severity"
-      remove_field => "syslog_severity_code"
-      remove_field => "syslog_program"
-      remove_field => "syslog_timestamp"
-      remove_field => "syslog_hostname"
-
-      split =>  { "audit_event_origin" => ", " }
-
-      add_field => { "[@source][component]" => "UAA" }
-      add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
-      convert => { "jobindex" => "integer" }
-    }
-
-    mutate {
-      remove_field => "jobname"
-      rename => { "jobindex"       => "[@source][instance]" }
-      rename => { "loglevel"       => "[@level]" }
-
-      rename => { "pid"            => "[UAA][pid]" }
-      rename => { "thread_name"     => "[UAA][thread_name]" }
-
-      rename => { "audit_event_type"              => "[UAA][type]" }
-      rename => { "audit_event_remote_address"    => "[UAA][remote_address]" }
-      rename => { "audit_event_data"              => "[UAA][data]" }
-      rename => { "audit_event_principal"         => "[UAA][principal]" }
-      rename => { "audit_event_origin"            => "[UAA][origin]" }
-      rename => { "audit_event_identity_zone_id"  => "[UAA][identity_zone_id]" }
-    }
-
-    mutate {
-      replace => { "[@metadata][index]" => "platform" }
-      replace => { "[@type]" => "uaa-audit" }
-    }
-  }
 }
+


### PR DESCRIPTION
This PR includes filters refactoring and minor rework. 

Refactoring includes changing snippets to follow the same structure - this makes them more readable and easier to edit.

Rework includes the following useful changes:

- Uaa, firehose: add @shipper.* fields; do not use old 'remove' option in mutate (replaced with 'remove_field'); lowercase UAA fields (UAA.* -> uaa.*).
- Firehose: replace unicode Null character (\0000) with "" and drop empty logs; fixed convertion of HTTP status code to @level.
- Common fields changes: uppercase @level field; rename field tags -> @tags.