### PR TITLE
Filters decomposition & additional processing

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -1,10 +1,5 @@
-# Index
-if ! [@metadata][index] {
-    # All logs start being sent to the unparsed index. The filters below will route them to the @index=app* or @index=platform.
-    mutate {
-        add_field => { "[@metadata][index]" => "unparsed" }
-    }
-}
+# Setup snippet (should precede all other snippets)
+<%= File.read('src/logstash-filters/snippets/setup.conf') %>
 
 # Include snippets
 
@@ -16,10 +11,8 @@ if ! [@metadata][index] {
 
 <%= File.read('src/logstash-filters/snippets/vcap.conf') %>
 
+<%= File.read('src/logstash-filters/snippets/undefined.conf') %>
 
-# Cleanup
-mutate {
-  rename => { "[tags]" => "[@tags]" }
-  uppercase => [ "[@level]" ]
-  remove_field => [ "@version" ]
-}
+
+# Teardown snippet (should follow all other snippets)
+<%= File.read('src/logstash-filters/snippets/teardown.conf') %>

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -3,7 +3,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
     # Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)
 
     json {
-      source => '@message'
+      source => "@message"
     }
 
     if "_jsonparsefailure" in [tags] {
@@ -80,22 +80,10 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
         }
 
-        # remove syslog_ fields and unnecessary fields
+        # remove unnecessary fields
         mutate {
-            remove_field => "syslog_severity_code"
-            remove_field => "syslog_facility_code"
-            remove_field => "syslog_facility"
-            remove_field => "syslog_severity"
-            remove_field => "syslog_pri"
-            remove_field => "syslog_program"
-            remove_field => "syslog_pid"
-            remove_field => "syslog_hostname"
-            remove_field => "syslog_timestamp"
-
             remove_field => "time"
             remove_field => "timestamp"
-            remove_field => "received_from"
-            remove_field => "received_at"
         }
         
         # --------- specific index & type, tags -----------

--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -54,19 +54,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "haproxy" {
         replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
       }
 
-      # remove syslog_ fields
-      mutate {      
-        remove_field => "syslog_pri"
-        remove_field => "syslog_facility"
-        remove_field => "syslog_facility_code"
-        remove_field => "syslog_message"
-        remove_field => "syslog_severity"
-        remove_field => "syslog_severity_code"
-        remove_field => "syslog_program"
-        remove_field => "syslog_timestamp"
-        remove_field => "syslog_hostname"
-      }
-
       # -------- specific index & type, tags ----------
       mutate {
         replace => { "[@metadata][index]" => "platform" }

--- a/src/logsearch-config/src/logstash-filters/snippets/setup.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/setup.conf
@@ -1,0 +1,16 @@
+# Replace the unicode Null character \u0000 with \n
+# Ignore logs with empty msg
+mutate {
+    gsub => [ "@message", '\u0000', ""]
+}
+if [@message] =~ /^\s*$/ or [@message] =~ /^#.*$/ {
+    drop { }
+}
+
+# Set index
+# All logs start being sent to the unparsed index. The filters below will route them to the @index=app* or @index=platform.
+if ! [@metadata][index] {
+    mutate {
+        add_field => { "[@metadata][index]" => "unparsed" }
+    }
+}

--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -1,0 +1,50 @@
+# Apply default settings for mondatory fields if not set & cleanup unnecessary fields
+
+# Set syslog @level (if @level is not set yet)
+if ![@level] and [syslog_severity_code] { # @level
+
+    if [syslog_severity_code] <= 3 { # 0-Emergency, 1-Alert, 2-Critical, 3-Error
+        mutate {
+          add_field => { "@level" => "ERROR" }
+        }
+    } else if [syslog_severity_code] <= 5 { # 4-Warning, 5-Notice
+        mutate {
+          add_field => { "@level" => "WARN" }
+        }
+    } else if [syslog_severity_code] == 6 { # 6-Informational
+        mutate {
+          add_field => { "@level" => "INFO" }
+        }
+    } else if [syslog_severity_code] == 7 { #7-Debug
+        mutate {
+          add_field => { "@level" => "DEBUG" }
+        }
+    }
+}
+
+# Set [@source][component] (if not set yet)
+if ![@source][component] and [syslog_program] {
+    mutate {
+      add_field => { "[@source][component]" => "%{syslog_program}" } # specific value
+    }
+}
+
+# Remove syslog_ fields
+mutate {      
+  remove_field => "syslog_pri"
+  remove_field => "syslog_facility"
+  remove_field => "syslog_facility_code"
+  remove_field => "syslog_message"
+  remove_field => "syslog_severity"
+  remove_field => "syslog_severity_code"
+  remove_field => "syslog_program"
+  remove_field => "syslog_timestamp"
+  remove_field => "syslog_hostname"
+}
+
+# Cleanup
+mutate {
+  rename => { "[tags]" => "[@tags]" }
+  uppercase => [ "[@level]" ]
+  remove_field => [ "@version" ]
+}

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -73,19 +73,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
             replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
         }
 
-        # remove syslog_ fields
-        mutate {      
-          remove_field => "syslog_pri"
-          remove_field => "syslog_facility"
-          remove_field => "syslog_facility_code"
-          remove_field => "syslog_message"
-          remove_field => "syslog_severity"
-          remove_field => "syslog_severity_code"
-          remove_field => "syslog_program"
-          remove_field => "syslog_timestamp"
-          remove_field => "syslog_hostname"
-        }
-
         # -------- specific index & type, tags ----------
         mutate {
           replace => { "[@metadata][index]" => "platform" }

--- a/src/logsearch-config/src/logstash-filters/snippets/undefined.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/undefined.conf
@@ -1,0 +1,47 @@
+if [@type] in ["syslog", "relp"] and ![@source][component] {
+
+    # Undefined logs - try parsing with default CF format
+
+    grok {
+        match => { "@message" => "(?:\[job=%{NOTSPACE:jobname}|-) +(?:index=%{NOTSPACE:jobindex}\]|-)%{SPACE}%{GREEDYDATA:@message}" }
+        overwrite => [ "@message" ] # @message
+        tag_on_failure => [
+            "_grokparsefailure-cf"
+        ]
+    }
+
+    if !("_grokparsefailure-cf" in [tags]) {
+
+      # ------------- common fields ------------------
+
+      # @source (component, name, instance, host) & @shipper
+      mutate {
+        add_field => { "[@source][component]" => "%{syslog_program}" } # specific value
+        add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
+      }
+      mutate {
+        convert => { "jobindex" => "integer" }
+      }
+      mutate {
+        rename => { "jobindex" => "[@source][instance]" }
+        remove_field => "jobname"
+        replace => [ "[@job][host]", "%{[@source][host]}" ]
+      }
+
+      # @shipper
+      mutate {
+        replace => [ "[@shipper][priority]", "%{syslog_pri}" ]
+        replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
+      }
+
+      # --------- specific index & type, tags -----------
+      mutate {
+        replace => { "[@metadata][index]" => "platform" }
+        replace => { "[@type]" => "%{[@type]}_cf" }
+        add_tag => "cf"
+      }
+      # --------------------------------------------------
+
+    }
+    
+}

--- a/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
@@ -57,19 +57,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
             replace => [ "[@shipper][name]", "%{syslog_program}_%{[@type]}" ]
         }
 
-        # remove syslog_ fields
-        mutate {      
-          remove_field => "syslog_pri"
-          remove_field => "syslog_facility"
-          remove_field => "syslog_facility_code"
-          remove_field => "syslog_message"
-          remove_field => "syslog_severity"
-          remove_field => "syslog_severity_code"
-          remove_field => "syslog_program"
-          remove_field => "syslog_timestamp"
-          remove_field => "syslog_hostname"
-        }
-
         # --------- specific index & type, tags -----------
         mutate {
           replace => { "[@metadata][index]" => "platform" }


### PR DESCRIPTION
This PR includes snippets refactoring that makes them having more convenient structure. The idea is to move common setup/teardown logic from all snippets to separate scripts to remove code duplication, make snippets more simple and readable.

Additionally 'setup' logic now includes rules for setting default values for `@level` and `@source.component` fields. It is possible that these fields are not set in snippets (because of wrong message format etc.) so we need to set the fields with default values, because the fields are significant some (those we want to see in Kibana table, search by etc.).

Also this PR includes additional processing rules of 'undefined' logs. Because we still need to parse CF logs that were not parsed by any of existing special snippets (uaa, vcap, etc.).

Changes include:
1) Filters decomosition
Move common 'init' logic to 'setup' script and call it from default.conf.erb before all snippets. Similarly move all common 'cleanup' logic to teardown.conf and call it after all snippets.

2) Additional procesing:
- Add processing of undefined CF logs in undefined.conf snippet (parsing of those logs that are not parsed by any of existing special snippets like uaa, vcap etc.).
- Make teardown.conf set `@level` and `@source.component` fields from corresponding syslog* fields if they haven't been set in snippets (we need to have at least some value for these fields cause they are significant some).