### PR TITLE
Firehose parsing rework

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -4,6 +4,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
     json {
       source => "@message"
+      target => "app"
     }
 
     if "_jsonparsefailure" in [tags] {
@@ -19,34 +20,34 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         # -------- message additional parsing ----------
 
         # by default all logs should have event_type LogMessage
-        if ![event_type] {
+        if ![app][event_type] {
             mutate {
-                add_field => [ "event_type", "LogMessage" ] 
+                add_field => [ "[app][event_type]", "LogMessage" ] 
             }
         }
 
         # app @source
         mutate {
-            rename => { "[cf_org_id]"     => "[@source][org][id]" }
-            rename => { "[cf_org_name]"   => "[@source][org][name]" }
-            rename => { "[cf_space_id]"   => "[@source][space][id]" }
-            rename => { "[cf_space_name]" => "[@source][space][name]" }
-            rename => { "[cf_app_id]"     => "[@source][app][id]" }
-            rename => { "[cf_app_name]"   => "[@source][app][name]" }
+            rename => { "[app][cf_org_id]"     => "[@source][org_id]" }
+            rename => { "[app][cf_org_name]"   => "[@source][org]" }
+            rename => { "[app][cf_space_id]"   => "[@source][space_id]" }
+            rename => { "[app][cf_space_name]" => "[@source][space]" }
+            rename => { "[app][cf_app_id]"     => "[@source][app_id]" }
+            rename => { "[app][cf_app_name]"   => "[@source][app]" }
             
-            rename => { "[origin]"        => "[@source][origin]" } # CF logging component        
-            rename => { "[message_type]"  => "[@source][message_type]" } # OUT/ ERR
+            rename => { "[app][origin]"        => "[@source][origin]" } # CF logging component        
+            rename => { "[app][message_type]"  => "[@source][message_type]" } # OUT/ ERR
         }
 
         # Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
         mutate {
-          gsub => [ "[msg]", '\u2028', "
+          gsub => [ "[app][msg]", '\u2028', "
 "
           ]
         } 
         # Replace the unicode Null character \u0000 with \n
         mutate {
-          gsub => [ "[msg]", '\u0000', ""]
+          gsub => [ "[app][msg]", '\u0000', ""]
         }
         # Ignore logs with empty msg
         if [msg] =~ /^\s*$/ or [msg] =~ /^#.*$/ {
@@ -55,12 +56,12 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
         # ------------ specific fields ----------------
         date {
-            match => [ "time", "ISO8601" ] # date
+            match => [ "[app][time]", "ISO8601" ] # date
         }
 
         mutate {
-            rename => { "[msg]" => "[@message]" } # @message
-            rename => { "[level]" => "[@level]" } # @level
+            rename => { "[app][msg]" => "[@message]" } # @message
+            rename => { "[app][level]" => "[@level]" } # @level
         }
 
         # ------------- common fields ------------------
@@ -68,8 +69,8 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         # @source (component, name, instance, host) & @shipper
         mutate {
           rename => { "[host]" => "[@source][host]" }
-          rename => { "[source_type]" => "[@source][component]" }
-          rename => { "[source_instance]" => "[@source][instance]" }
+          rename => { "[app][source_type]" => "[@source][component]" }
+          rename => { "[app][source_instance]" => "[@source][instance]" }
           add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
           convert => { "[@source][instance]" => "integer" }
         }
@@ -82,37 +83,20 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
         # remove unnecessary fields
         mutate {
-            remove_field => "time"
-            remove_field => "timestamp"
+            remove_field => "[app][time]"
+            remove_field => "[app][timestamp]"
         }
         
         # --------- specific index & type, tags -----------
-        mutate { replace => [ "[@metadata][index]", "app-%{[@source][org][name]}-%{[@source][space][name]}" ] } # custom index name
+        mutate { replace => [ "[@metadata][index]", "app-%{[@source][org]}-%{[@source][space]}" ] } # custom index name
         mutate { lowercase => [ "[@metadata][index]" ] }
 
         mutate {
-            replace => { "[@type]" => "%{[event_type]}" }
-            remove_field => "[event_type]"
+            replace => { "[@type]" => "%{[app][event_type]}" }
+            remove_field => "[app][event_type]"
             add_tag => [ 'firehose' ]
         }
         # ----------- special cases processing -------------
-        # ----------------------------
-        # Special Case - Metrics logs |
-        # ----------------------------
-        if( [@type] == "ContainerMetric" ) {
-          mutate {
-            add_tag => "ContainerMetric"
-            replace => {"[@source][component]" => "METRIC"}
-            replace => {"[@source][instance]" => "%{[instance_index]}"}
-          }
-          mutate {
-            rename => { "[cpu_percentage]" => "[container][cpu_percentage]" }
-            rename => { "[memory_bytes]" => "[container][memory_bytes]" }
-            rename => { "[disk_bytes]" => "[container][disk_bytes]" }
-            remove_field => "[instance_index]"
-          }
-        }
-
         # ------------------------
         # Special Case - RTR logs |
         # ------------------------
@@ -120,48 +104,51 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
             grok {
 
                 #cf-release > v222 - includes x_forwarded_proto
-                match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[RTR][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                match => { '@message' => '%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[rtr][vcap_request_id]} response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
                 
                 #cf-release > v205 - includes RequestBytesReceived
-                match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                match => { '@message' => '%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[rtr][vcap_request_id]} response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
                 
                 #cf-release <= v205
-                match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
-                overwrite => [ "time" ]
+                match => { '@message' => '%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[rtr][vcap_request_id]} response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                
                 tag_on_failure => [ 'fail/firehose/RTR' ]
                 add_tag => "RTR"
             }
 
             if !("fail/firehose/RTR" in [tags]) {
-                date {
-                    match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
+                
+                if [rtr_time] {
+                  date {
+                      match => [ "rtr_time", "dd/MM/y:HH:mm:ss Z" ] # date
+                  }
                 }
 
                 # set @level based on HTTP status
-                if [RTR][status] >= 400 {
+                if [rtr][status] >= 400 {
                     mutate {
                         replace => { "[@level]" => "ERROR" } # @level
                     }
                 }
 
-                if [RTR][x_forwarded_for] {
+                if [rtr][x_forwarded_for] {
                     mutate {
-                        gsub => ["[RTR][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
-                        split => ["[RTR][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
+                        gsub => ["[rtr][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
+                        split => ["[rtr][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
                     }
 
                    ruby {
-                       code => "event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int"
+                       code => "event['rtr']['response_time_ms'] = (event['rtr']['response_time_sec']*1000).to_int"
                        remove_field => "response_time_sec"
                    }
 
                    mutate {
-                      add_field => ["[RTR][remote_addr]", "%{[RTR][x_forwarded_for][0]}"]
+                      add_field => ["[rtr][remote_addr]", "%{[rtr][x_forwarded_for][0]}"]
                    }
 
-                   if ([RTR][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
+                   if ([rtr][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
                        geoip {
-                         source => "[RTR][remote_addr]"
+                         source => "[rtr][remote_addr]"
                        }
                    }
                 }
@@ -186,8 +173,10 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
             if !("_jsonparsefailure" in [tags]) {
 
-              date {
-                match => [ "[log][timestamp]", "ISO8601" ] # date
+              if( [log][timestamp] ) {
+                date {
+                  match => [ "[log][timestamp]", "ISO8601" ] # date
+                }
               }
 
               # conacat message and exception


### PR DESCRIPTION
1) Delete ContainerMetric special processing for now.
The rules look out-of-date so it makes sense to delete them for now as obsolete. 
Then we will add actual parsing rules for metrics after thorough investigation of possible formats and testing.

2) Fields refactoring: 
- lowercase RTR fields (RTR.* -> rtr.*); 
To be convenient with other fields.

- store application json fields to app.* fields; 
We need to distinguish between fields retrieved from application JSON message and other fields.

- rename firehose `@source.*` fields to avoid too long names (`[@source][org][name] -> [@source][org]`, etc.). 
Long names are not really useful in Kibana table (column header is longer than it's content).

3) Minor syntax fixes & additional fields presence checks (to avoid logstash warnings when parsing).

Note, that fields rename (`[@source][org][name] -> [@source][org]`, etc.) will take effect in new app* indices only. Current app* index can be broken after the change is applied because of ES mappings conflict for affected fields. The way to fix it and get new documents added to the index is to delete current index (app* index for today) after this change is applied.