### PR TITLE
Unify events timestamp by setting 'date' from metron_agent timestamp

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -3,6 +3,9 @@
 
 # Include snippets
 
+# NOTE: @timestamp for CF components logs is set in logsearch-boshrelease from syslog_timestamp (timestamp set by metron_agent).
+# Timestamp set by metron_agent for Firehose logs is <message JSON>.timestamp field. (Thats why Firehose snippet sets date with it).
+
 <%= File.read('src/logstash-filters/snippets/firehose.conf') %>
 
 <%= File.read('src/logstash-filters/snippets/haproxy.conf') %>

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -55,8 +55,18 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         }
 
         # ------------ specific fields ----------------
+        
+        # @timestamp
+        ruby { # convert [app][timestamp] from nanosec-from-epoch number to Datetime
+            init => "require 'time'"
+            code => "time_in_nanosec_from_epoch = event['[app][timestamp]']
+                     time_in_seconds = time_in_nanosec_from_epoch / 10 ** 9
+                     milliseconds = time_in_nanosec_from_epoch % 10 ** 9 / 1000.to_f
+                     event['[app][timestamp]'] = Time.at(time_in_seconds, milliseconds).iso8601(6)
+                     "
+        }
         date {
-            match => [ "[app][time]", "ISO8601" ] # date
+            match => [ "[app][timestamp]", "ISO8601" ] # date
         }
 
         mutate {
@@ -119,8 +129,8 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
             if !("fail/firehose/RTR" in [tags]) {
                 
                 if [rtr_time] {
-                  date {
-                      match => [ "rtr_time", "dd/MM/y:HH:mm:ss Z" ] # date
+                  mutate {
+                    rename => { "rtr_time" => "[rtr][timestamp]" }
                   }
                 }
 
@@ -172,12 +182,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
             }
 
             if !("_jsonparsefailure" in [tags]) {
-
-              if( [log][timestamp] ) {
-                date {
-                  match => [ "[log][timestamp]", "ISO8601" ] # date
-                }
-              }
 
               # conacat message and exception
               if ( [log][exception] ) {

--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -8,12 +8,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "haproxy" {
     if !("fail/cloudfoundry/haproxy/grok" in [tags]) {
 
       # ------------ specific fields ----------------
-      if [haproxy][accept_date] { # date
-        date {
-          match => [ "[haproxy][accept_date]", "dd/MMM/YYYY:HH:mm:ss.SSS" ]
-          remove_field => [ "[haproxy][accept_date]" ]
-        }
-      }
 
       mutate {
         rename => {"message" => "@message"} # @message

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -13,10 +13,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
     if !("fail/cloudfoundry/uaa" in [tags]) {
 
         # ------------ specific fields ----------------
-        date {
-            match => [ "uaa_timestamp", "ISO8601" ]
-            remove_field => "uaa_timestamp"
-        }
+
         mutate {
           rename => { "loglevel" => "[@level]" } # @level
         }
@@ -41,8 +38,9 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
             split =>  { "audit_event_origin" => ", " }
         }
         mutate {
-            rename => { "pid"            => "[uaa][pid]" }
-            rename => { "thread_name"     => "[uaa][thread_name]" }
+            rename => { "pid"                           => "[uaa][pid]" }
+            rename => { "thread_name"                   => "[uaa][thread_name]" }
+            rename => { "uaa_timestamp"                 => "[uaa][timestamp]" }
             rename => { "audit_event_type"              => "[uaa][type]" }
             rename => { "audit_event_remote_address"    => "[uaa][remote_address]" }
             rename => { "audit_event_data"              => "[uaa][data]" }


### PR DESCRIPTION
At the moment some components (haproxy, uaa, app in JSON format) set `date` to their log events from specific `timestamp` fields that come together with log events. From the other hand for logs of other components (cloud_controller, hm9000, app in unknown format etc.) `date` is set from `syslog_timestamp` field which contains **metron_agent** timestamp (see https://github.com/logsearch/logsearch-boshrelease/blob/v201.0.16/src/logsearch-config/src/logstash-filters/snippets/syslog_standard.conf).

We need to be really sensible when setting `date` filter because it affects events distribution on a timeline in Kibana, in other words it specifies events order. So it really makes sense to set `date` to some unified time of events' lifecycle. The most appropriate is **metron_agent timestamp** because all events should have this timestamp passed.

The PR makes necessary changes described above. Here they are:

1) Do not set event 'date' from specific logs timestamp fields anymore. Set it from metron_agent timestamp instead - to have time consistency between logs of different sources (haproxy, uaa etc.).

2) Fix firehose parsing to set 'date' from <JSON>.timestamp field instead of <JSON>.time because in fact 'timestamp' is right field that contains timestamp from metron_agent (see https://github.com/cloudfoundry-community/firehose-to-syslog/issues/79 for description of time fields in firehose JSON).