### PR TITLE
Filters & fields refactoring

### DIFF
--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -3,6 +3,8 @@
 
 # Include snippets
 
+# NOTE: All parsed data should include @message, @level and @source.component. Otherwise these fields are set from syslog_ fields in teardown script afterwards.
+
 # NOTE: @timestamp for CF components logs is set in logsearch-boshrelease from syslog_timestamp (timestamp set by metron_agent).
 # Timestamp set by metron_agent for Firehose logs is <message JSON>.timestamp field. (Thats why Firehose snippet sets date with it).
 

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -69,9 +69,10 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
             match => [ "[app][timestamp]", "ISO8601" ] # date
         }
 
+        # @message and @level
         mutate {
-            rename => { "[app][msg]" => "[@message]" } # @message
-            rename => { "[app][level]" => "[@level]" } # @level
+            rename => { "[app][msg]" => "@message" } # @message
+            rename => { "[app][level]" => "@level" } # @level
         }
 
         # ------------- common fields ------------------
@@ -95,6 +96,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         mutate {
             remove_field => "[app][time]"
             remove_field => "[app][timestamp]"
+            remove_field => "[app][cf_origin]"
         }
         
         # --------- specific index & type, tags -----------
@@ -102,9 +104,12 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         mutate { lowercase => [ "[@metadata][index]" ] }
 
         mutate {
-            replace => { "[@type]" => "%{[app][event_type]}" }
-            remove_field => "[app][event_type]"
-            add_tag => [ 'firehose' ]
+          add_field => { "@input" => "%{@type}" }
+        }
+        mutate {
+          replace => { "@type" => "%{[app][event_type]}" }
+          remove_field => "[app][event_type]"
+          add_tag => [ "app" ]
         }
         # ----------- special cases processing -------------
         # ------------------------
@@ -137,7 +142,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
                 # set @level based on HTTP status
                 if [rtr][status] >= 400 {
                     mutate {
-                        replace => { "[@level]" => "ERROR" } # @level
+                        replace => { "@level" => "ERROR" } # @level
                     }
                 }
 
@@ -177,8 +182,8 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           if [@message] =~ /^\s*{".*}\s*$/ {
           
             json {
-              source => '@message'
-              target => 'log'
+              source => "@message"
+              target => "log"
             }
 
             if !("_jsonparsefailure" in [tags]) {
@@ -195,7 +200,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
               } else {
 
                 mutate {
-                  rename => { "[log][message]" => "[@message]" }
+                  rename => { "[log][message]" => "@message" }
                 }
               }
 
@@ -233,7 +238,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           }
 
           mutate {
-            rename => { "[log][level]" => "[@level]" } # @level
+            rename => { "[log][level]" => "@level" } # @level
           }
 
         }

--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -30,6 +30,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "haproxy" {
 
       # @source (component, name, instance, host) & @shipper
       mutate {
+        rename => { "[host]" => "[@source][host]" }
         add_field => { "[@source][component]" => "haproxy" } # specific value
         add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
       }
@@ -39,7 +40,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "haproxy" {
       mutate {
         rename => { "jobindex" => "[@source][instance]" }
         remove_field => "jobname"
-        replace => [ "[@job][host]", "%{[@source][host]}" ]
       }
 
       # @shipper
@@ -50,8 +50,11 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "haproxy" {
 
       # -------- specific index & type, tags ----------
       mutate {
+        add_field => { "@input" => "%{@type}" }
+      }
+      mutate {
         replace => { "[@metadata][index]" => "platform" }
-        replace => { "[@type]" => "haproxy_cf" }
+        replace => { "@type" => "haproxy_cf" }
         add_tag => "haproxy-cf"
       }
       # -----------------------------------------------

--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -1,4 +1,4 @@
-# Apply default settings for mondatory fields if not set & cleanup unnecessary fields
+# -- Apply default settings for mondatory fields (if not set)
 
 # Set syslog @level (if @level is not set yet)
 if ![@level] and [syslog_severity_code] { # @level
@@ -29,6 +29,8 @@ if ![@source][component] and [syslog_program] {
     }
 }
 
+# -- Cleanup unnecessary fields
+
 # Remove syslog_ fields
 mutate {      
   remove_field => "syslog_pri"
@@ -40,11 +42,12 @@ mutate {
   remove_field => "syslog_program"
   remove_field => "syslog_timestamp"
   remove_field => "syslog_hostname"
+  remove_field => "syslog_pid"
 }
 
 # Cleanup
 mutate {
   rename => { "[tags]" => "[@tags]" }
-  uppercase => [ "[@level]" ]
+  uppercase => [ "@level" ]
   remove_field => [ "@version" ]
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -2,7 +2,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
 
     grok {
         match => { "@message" =>
-        "\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\]%{SPACE}\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]"
+        "\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\]%{SPACE}\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}(?<message>(%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\))):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]"
         }
         tag_on_failure => [
             "fail/cloudfoundry/uaa"
@@ -15,7 +15,8 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
         # ------------ specific fields ----------------
 
         mutate {
-          rename => { "loglevel" => "[@level]" } # @level
+          rename => { "message" => "@message" } # @message
+          rename => { "loglevel" => "@level" } # @level
         }
 
         # UAA specific
@@ -53,6 +54,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
 
         # @source (component, name, instance, host) & @shipper
         mutate {
+          rename => { "[host]" => "[@source][host]" }
           add_field => { "[@source][component]" => "uaa" } # specific value
           add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
         }
@@ -62,7 +64,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
         mutate {
           rename => { "jobindex" => "[@source][instance]" }
           remove_field => "jobname"
-          replace => [ "[@job][host]", "%{[@source][host]}" ]
         }
 
         # @shipper
@@ -73,8 +74,11 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
 
         # -------- specific index & type, tags ----------
         mutate {
+          add_field => { "@input" => "%{@type}" }
+        }
+        mutate {
           replace => { "[@metadata][index]" => "platform" }
-          replace => { "[@type]" => "uaa_cf" }
+          replace => { "@type" => "uaa_cf" }
           add_tag => "uaa-cf"
         }
         # -----------------------------------------------

--- a/src/logsearch-config/src/logstash-filters/snippets/undefined.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/undefined.conf
@@ -6,16 +6,17 @@ if [@type] in ["syslog", "relp"] and ![@source][component] {
         match => { "@message" => "(?:\[job=%{NOTSPACE:jobname}|-) +(?:index=%{NOTSPACE:jobindex}\]|-)%{SPACE}%{GREEDYDATA:@message}" }
         overwrite => [ "@message" ] # @message
         tag_on_failure => [
-            "_grokparsefailure-cf"
+            "fail/cloudfoundry/grok"
         ]
     }
 
-    if !("_grokparsefailure-cf" in [tags]) {
+    if !("fail/cloudfoundry/grok" in [tags]) {
 
       # ------------- common fields ------------------
 
       # @source (component, name, instance, host) & @shipper
       mutate {
+        rename => { "[host]" => "[@source][host]" }
         add_field => { "[@source][component]" => "%{syslog_program}" } # specific value
         add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
       }
@@ -25,7 +26,6 @@ if [@type] in ["syslog", "relp"] and ![@source][component] {
       mutate {
         rename => { "jobindex" => "[@source][instance]" }
         remove_field => "jobname"
-        replace => [ "[@job][host]", "%{[@source][host]}" ]
       }
 
       # @shipper
@@ -36,8 +36,11 @@ if [@type] in ["syslog", "relp"] and ![@source][component] {
 
       # --------- specific index & type, tags -----------
       mutate {
+        add_field => { "@input" => "%{@type}" }
+      }
+      mutate {
         replace => { "[@metadata][index]" => "platform" }
-        replace => { "[@type]" => "%{[@type]}_cf" }
+        replace => { "@type" => "%{[@type]}_cf" }
         add_tag => "cf"
       }
       # --------------------------------------------------

--- a/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
@@ -1,6 +1,6 @@
 if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
 
-    # Parse logs from Cloud Foundry components (vcap). Note that UAA logs are handled by rules in uaa.conf snippet.
+    # Parse Cloud Foundry logs from syslog_aggregator
 
     grok {
         match => { "@message" => "(?:\[job=%{NOTSPACE:jobname}|-) +(?:index=%{NOTSPACE:jobindex}\]|-)%{SPACE}%{GREEDYDATA:@message}" }
@@ -13,7 +13,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
         # -------- message additional parsing & specific fields ----------
 
         # JSON parsing
-        if [@message] =~ /^\{/ {
+        if [@message] =~ /^\s*{".*}\s*$/ {
             
             json {
               source => "@message"
@@ -25,10 +25,10 @@ if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
               convert => { "[vcap][log_level]" => "string" }
             }
             mutate {
-              rename => { "[vcap][log_level]" => "[@level]" } # @level
+              rename => { "[vcap][log_level]" => "@level" } # @level
             }
             mutate {
-              rename => { "[vcap][message]" => "[@message]" } # @message
+              rename => { "[vcap][message]" => "@message" } # @message
             }
 
         }
@@ -40,6 +40,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
           code => "event['[@source][component]'] = event['syslog_program'][5..-1]" # minus "vcap." prefix
         }
         mutate {
+          rename => { "[host]" => "[@source][host]" }
           add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
         }
         mutate {
@@ -48,7 +49,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
         mutate {
           rename => { "jobindex" => "[@source][instance]" }
           remove_field => "jobname"
-          replace => [ "[@job][host]", "%{[@source][host]}" ]
         }
 
         # @shipper
@@ -59,8 +59,11 @@ if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
 
         # --------- specific index & type, tags -----------
         mutate {
+          add_field => { "@input" => "%{@type}" }
+        }
+        mutate {
           replace => { "[@metadata][index]" => "platform" }
-          replace => { "[@type]" => "vcap_cf" }
+          replace => { "@type" => "vcap_cf" }
           add_tag => "vcap-cf"
         }
         # --------------------------------------------------


### PR DESCRIPTION
This PR includes filters & fields refactoring - cleanup useless fields, set mandatory fields (such as `@message`) for all log types, set missing fields etc.. The changes are the following:

Add `@input` field. Remove `syslog_pid`; Remove `[@job][host]`.
Set `[@source][host]` where it was missing.
Set `@message` for uaa.
Check JSON format more strictly (vcap).
Rename grok fail tag (undefined);
Remove square brackets where we access simple fields (e.g. use `@level` instead of `[@level]`).