### PR TITLE
Enable logsearch-for-cloudfoundry to be tested on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+---
+sudo: false
+language: ruby
+rvm:
+  - jruby-9.0.5.0
+jdk:
+  - openjdk7
+before_install:
+  - gem update --system
+  - gem --version
+install:
+  - cd $TRAVIS_BUILD_DIR/src/logsearch-config
+  - gem install rake
+  - bin/install-dependencies
+script:
+  - bin/test
+notifications:
+  email: false


### PR DESCRIPTION
Hi @axelaris !
I added `.travis.yml` file, this file execute tests against logsearch-for-cloudfoundry filters which are located under `src/logsearch-config` folder.
Current tests are outdated, but @hannayurkevich already working on it. After the tests will be done we can enable Travis CI for the repo.
Thanks! 