### PR TITLE
App index name fix

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -109,8 +109,15 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
         }
 
         # --------- index, @type and tags -----------
-        mutate { replace => { "[@metadata][index]" => "app-%{[@source][org]}-%{[@source][space]}" } } # custom index name
-        mutate { lowercase => [ "[@metadata][index]" ] }
+        # app index name
+        mutate { replace => { "[@metadata][index]" => "app" } }
+        if [@source][org] {
+            mutate { replace => { "[@metadata][index]" => "%{[@metadata][index]}-%{[@source][org]}" } }
+            if [@source][space] {
+                mutate { replace => { "[@metadata][index]" => "%{[@metadata][index]}-%{[@source][space]}" } }
+            }
+            mutate { lowercase => [ "[@metadata][index]" ] }
+        }
 
         mutate {
           replace => { "@type" => "%{[app][event_type]}" }


### PR DESCRIPTION
Check for existence of `[@source][org]` and `[@source][space]` before constructing app index name. Otherwise we can get broken index name (if any of these fields are missing).