### PR TITLE
Fix deprecated bin/plugin call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Logsearch for Cloud Foundry
 
+### Build status
+
+[![Build Status](https://travis-ci.org/cloudfoundry-community/logsearch-for-cloudfoundry.svg?branch=master)](https://travis-ci.org/cloudfoundry-community/logsearch-for-cloudfoundry)
+
 LogStash parsing rules for some CloudFoundry-specific log formats:
 
 * App logs

--- a/src/logsearch-config/bin/install-dependencies
+++ b/src/logsearch-config/bin/install-dependencies
@@ -20,7 +20,7 @@ elif [ ! -e vendor/logstash-$LOGSTASH_VERSION ] ; then
     tar xz -C vendor/logstash-$LOGSTASH_VERSION --strip-components 1
   (
     cd vendor/logstash-$LOGSTASH_VERSION
-    bin/plugin install --development # so we can use logstash rspec
+    bin/logstash-plugin install --development # so we can use logstash rspec
   )
   ln -s $($getpath $SCRIPT_DIR/../vendor/logstash-$LOGSTASH_VERSION) vendor/logstash
 fi


### PR DESCRIPTION
Hi!
I fixed deprecated bin/plugin call. Instead of it we need to use `bin/logstash-plugin`.
Also i added the build status in readme page.
Thanks!
