### PR TITLE
Clarify haproxy grok patterns & Add UTs for haproxy-spec.rb  …

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -1,14 +1,24 @@
 if [@type] in ["syslog_cf", "relp_cf"] and [syslog_program] == "haproxy" {
 
+    # Grok patterns are based on http://www.haproxy.org/download/1.7/doc/configuration.txt
+    # Two formats are used accordingly:
+    # 8.2.3. HTTP log format
+    # 8.2.5. Error log format
+
     grok {
-      match => [ "@message", "%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]} %{NOTSPACE:[haproxy][backend_name]}/%{NOTSPACE:[haproxy][server_name]} %{INT:[haproxy][time_request]}/%{INT:[haproxy][time_queue]}/%{INT:[haproxy][time_backend_connect]}/%{INT:[haproxy][time_backend_response]}/%{NOTSPACE:[haproxy][time_duration]} %{INT:[haproxy][http_status_code]} %{NOTSPACE:[haproxy][bytes_read]} %{DATA:[haproxy][captured_request_cookie]} %{DATA:[haproxy][captured_response_cookie]} %{NOTSPACE:[haproxy][termination_state]} %{INT:[haproxy][actconn]}/%{INT:[haproxy][feconn]}/%{INT:[haproxy][beconn]}/%{INT:[haproxy][srvconn]}/%{NOTSPACE:[haproxy][retries]} %{INT:[haproxy][srv_queue]}/%{INT:[haproxy][backend_queue]} (%{GREEDYDATA:[haproxy][headers]})?( )?\"(?<message>(<BADREQ>|(%{WORD:[haproxy][http_verb]} (%{URIPROTO:[haproxy][http_proto]}://)?(?:%{USER:[haproxy][http_user]}(?::[^@]*)?@)?(?:%{URIHOST:[haproxy][http_host]})?(?:%{URIPATHPARAM:[haproxy][http_request]})?( HTTP/%{NUMBER:[haproxy][http_version]})?))?)\"" ]
-      match => [ "@message", "%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]}%{SPACE}%{GREEDYDATA:message}" ]
+      match => [ "@message", "%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]} %{NOTSPACE:[haproxy][backend_name]}/%{NOTSPACE:[haproxy][server_name]} %{INT:[haproxy][time_request]}/%{INT:[haproxy][time_queue]}/%{INT:[haproxy][time_backend_connect]}/%{INT:[haproxy][time_backend_response]}/%{NOTSPACE:[haproxy][time_duration]} %{INT:[haproxy][http_status_code]} %{NOTSPACE:[haproxy][bytes_read]} %{DATA:[haproxy][captured_request_cookie]} %{DATA:[haproxy][captured_response_cookie]} %{NOTSPACE:[haproxy][termination_state]} %{INT:[haproxy][actconn]}/%{INT:[haproxy][feconn]}/%{INT:[haproxy][beconn]}/%{INT:[haproxy][srvconn]}/%{NOTSPACE:[haproxy][retries]} %{INT:[haproxy][srv_queue]}/%{INT:[haproxy][backend_queue]} (\{%{DATA:[haproxy][captured_request_headers]}\})?( )?(\{%{DATA:[haproxy][captured_response_headers]}\})?( )?\"(?<message>(?<haproxy_http_request>(<BADREQ>|((%{WORD:[haproxy][http_request_verb]})?( %{GREEDYDATA})?))))\"" ]
+      match => [ "@message", "%{IP:[haproxy][client_ip]}:%{INT:[haproxy][client_port]} \[%{DATA:[haproxy][accept_date]}\] %{NOTSPACE:[haproxy][frontend_name]}/%{NOTSPACE:[haproxy][bind_name]}:%{SPACE}%{GREEDYDATA:message}" ]
       tag_on_failure => "fail/cloudfoundry/haproxy/grok"
     }
 
     if !("fail/cloudfoundry/haproxy/grok" in [tags]) {
 
         # ------------ specific fields ----------------
+        if [haproxy_http_request] {
+            mutate {
+              rename => {"haproxy_http_request" => "[haproxy][http_request]"}
+            }
+        }
 
         mutate {
           rename => {"message" => "@message"} # @message
@@ -28,7 +38,6 @@ if [@type] in ["syslog_cf", "relp_cf"] and [syslog_program] == "haproxy" {
               }
             }
         }
-
     }
 
     # -------- specific @source.component, type, tags ----------

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -5,11 +5,11 @@ if [@type] in ["syslog_cf", "relp_cf"] and [syslog_program] == "vcap.uaa" {
         "\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}(?<message>(%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\))):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]"
         }
         tag_on_failure => [
-            "fail/cloudfoundry/uaa"
+            "fail/cloudfoundry/uaa/grok"
         ]
     }
 
-    if !("fail/cloudfoundry/uaa" in [tags]) {
+    if !("fail/cloudfoundry/uaa/grok" in [tags]) {
 
         # ------------ specific fields ----------------
 

--- a/src/logsearch-config/test/logstash-filters/snippets/haproxy-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/haproxy-spec.rb
@@ -1,0 +1,163 @@
+# encoding: utf-8
+require 'test/filter_test_helpers'
+
+describe "Haproxy spec" do
+
+  before(:all) do
+    load_filters <<-CONFIG
+      filter {
+        #{File.read("src/logstash-filters/snippets/haproxy.conf")}
+      }
+    CONFIG
+  end
+
+  describe "Http log format" do
+    when_parsing_log(
+      "@type" => "syslog_cf",
+      "syslog_program" => "haproxy",
+      "@message" => "64.78.155.208:60677 [06/Jul/2016:13:59:57.770] https-in~ http-routers/node0 59841/0/0/157/60000 200 144206 reqC respC ---- 3/4/1/2/0 5/6 {reqHeaders} {respHeaders} \"GET /v2/apps?inline-relations-depth=2 HTTP/1.1\""
+    ) do
+
+      # Check that @message is parsed with no errors
+      it "does not include grok fail tag" do
+        expect(subject["tags"]).not_to include "fail/cloudfoundry/haproxy/grok"
+      end
+
+      # Check fields
+
+      # grok fields
+      it "sets [haproxy] fields from grok" do
+        expect(subject["haproxy"]["client_ip"]).to eq "64.78.155.208"
+        expect(subject["haproxy"]["client_port"]).to eq "60677"
+        expect(subject["haproxy"]["accept_date"]).to eq "06/Jul/2016:13:59:57.770"
+        expect(subject["haproxy"]["frontend_name"]).to eq "https-in~"
+        expect(subject["haproxy"]["backend_name"]).to eq "http-routers"
+        expect(subject["haproxy"]["server_name"]).to eq "node0"
+        expect(subject["haproxy"]["time_request"]).to eq "59841"
+        expect(subject["haproxy"]["time_queue"]).to eq "0"
+        expect(subject["haproxy"]["time_backend_connect"]).to eq "0"
+        expect(subject["haproxy"]["time_backend_response"]).to eq "157"
+        expect(subject["haproxy"]["time_duration"]).to eq "60000"
+        expect(subject["haproxy"]["http_status_code"]).to eq 200
+        expect(subject["haproxy"]["bytes_read"]).to eq "144206"
+        expect(subject["haproxy"]["captured_request_cookie"]).to eq "reqC"
+        expect(subject["haproxy"]["captured_response_cookie"]).to eq "respC"
+        expect(subject["haproxy"]["termination_state"]).to eq "----"
+        expect(subject["haproxy"]["actconn"]).to eq "3"
+        expect(subject["haproxy"]["feconn"]).to eq "4"
+        expect(subject["haproxy"]["beconn"]).to eq "1"
+        expect(subject["haproxy"]["srvconn"]).to eq "2"
+        expect(subject["haproxy"]["retries"]).to eq "0"
+        expect(subject["haproxy"]["srv_queue"]).to eq "5"
+        expect(subject["haproxy"]["backend_queue"]).to eq "6"
+        expect(subject["haproxy"]["captured_request_headers"]).to eq "reqHeaders"
+        expect(subject["haproxy"]["captured_response_headers"]).to eq "respHeaders"
+        expect(subject["haproxy"]["http_request"]).to eq "GET /v2/apps?inline-relations-depth=2 HTTP/1.1"
+        expect(subject["haproxy"]["http_request_verb"]).to eq "GET"
+      end
+
+      # @message & @level
+      it "sets @message from grok" do
+        expect(subject["@message"]).to eq "GET /v2/apps?inline-relations-depth=2 HTTP/1.1"
+      end
+
+      it "sets @level from grok" do
+        expect(subject["@level"]).to eq "INFO"
+      end
+
+      # basic fields
+      it "sets [@source][component]" do
+        expect(subject["@source"]["component"]).to eq "haproxy"
+      end
+
+      it "sets @type" do
+        expect(subject["@type"]).to eq "haproxy_cf"
+      end
+
+      it "sets 'uaa' tag" do
+        expect(subject["tags"]).to include "haproxy"
+      end
+
+    end
+  end
+
+  describe "Http log format - <BADREQ>" do
+    when_parsing_log(
+        "@type" => "syslog_cf",
+        "syslog_program" => "haproxy",
+        "@message" => "64.78.155.208:60677 [06/Jul/2016:13:59:57.770] https-in~ http-routers/node0 59841/0/0/157/60000 200 144206 reqC respC ---- 3/4/1/2/0 5/6 {reqHeaders} {respHeaders} \"<BADREQ>\""
+    ) do
+
+      # grok fields
+      it "sets [haproxy][request] from grok" do
+        expect(subject["haproxy"]["http_request"]).to eq "<BADREQ>"
+        expect(subject["haproxy"]["http_request_verb"]).to be_nil
+      end
+
+    end
+  end
+
+  describe "Http log format - ERROR level" do
+    when_parsing_log(
+        "@type" => "syslog_cf",
+        "syslog_program" => "haproxy",
+        "@message" => "64.78.155.208:60677 [06/Jul/2016:13:59:57.770] https-in~ http-routers/node0 59841/0/0/157/60000 400 144206 reqC respC ---- 3/4/1/2/0 5/6 {reqHeaders} {respHeaders} \"GET /v2/apps?inline-relations-depth=2 HTTP/1.1\""
+    ) do
+
+      # Check @level is set based on [haproxy][http_status_code]
+      it "sets @level to ERROR" do
+        expect(subject["@level"]).to eq "ERROR"
+      end
+
+    end
+  end
+
+  describe "Error log format" do
+    when_parsing_log(
+        "@type" => "syslog_cf",
+        "syslog_program" => "haproxy",
+        "@message" => "216.218.206.68:36743 [06/Jul/2016:07:16:34.605] https-in/1: SSL handshake failure"
+    ) do
+
+      # Check that @message is parsed with no errors
+      it "does not include grok fail tag" do
+        expect(subject["tags"]).not_to include "fail/cloudfoundry/haproxy/grok"
+      end
+
+      # Check fields
+
+      # grok fields
+      it "sets [haproxy] fields from grok" do
+        expect(subject["haproxy"]["client_ip"]).to eq "216.218.206.68"
+        expect(subject["haproxy"]["client_port"]).to eq "36743"
+        expect(subject["haproxy"]["accept_date"]).to eq "06/Jul/2016:07:16:34.605"
+        expect(subject["haproxy"]["frontend_name"]).to eq "https-in"
+        expect(subject["haproxy"]["bind_name"]).to eq "1"
+      end
+
+      # @message & @level
+      it "sets @message from grok" do
+        expect(subject["@message"]).to eq "SSL handshake failure"
+      end
+
+      it "sets @level from grok" do
+        expect(subject["@level"]).to be_nil
+      end
+
+      # basic fields
+      it "sets [@source][component]" do
+        expect(subject["@source"]["component"]).to eq "haproxy"
+      end
+
+      it "sets @type" do
+        expect(subject["@type"]).to eq "haproxy_cf"
+      end
+
+      it "sets 'uaa' tag" do
+        expect(subject["tags"]).to include "haproxy"
+      end
+
+    end
+  end
+
+end

--- a/src/logsearch-config/test/logstash-filters/snippets/uaa-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/uaa-spec.rb
@@ -20,7 +20,7 @@ describe "UAA spec" do
 
       # Check that @message is parsed with no errors
       it "does not include grok fail tag" do
-        expect(subject["tags"]).not_to include "fail/cloudfoundry/uaa"
+        expect(subject["tags"]).not_to include "fail/cloudfoundry/uaa/grok"
       end
 
       # Check fields
@@ -73,7 +73,7 @@ describe "UAA spec" do
 
       # Check that @message is parsed with no errors
       it "not include grok fail tag" do
-        expect(subject["tags"]).not_to include "fail/cloudfoundry/uaa"
+        expect(subject["tags"]).not_to include "fail/cloudfoundry/uaa/grok"
       end
 
       # Check fields
@@ -126,7 +126,7 @@ describe "UAA spec" do
 
       # Check that fail tag is set
       it "include grok fail tag" do
-        expect(subject["tags"]).to include "fail/cloudfoundry/uaa"
+        expect(subject["tags"]).to include "fail/cloudfoundry/uaa/grok"
       end
 
       # Check @message is the same as before parsing


### PR DESCRIPTION
1) Clarify haproxy grok patterns based on haproxy specification (http://www.haproxy.org/download/1.7/doc/configuration.txt)
2) Add UTs for haproxy parsing rules
3) Minor: fix uaa grok fail tag name (to be convenient with other snippets)