### PR TITLE
Filters: Support of integration tests & first ITs & refactoring of common fields

### DIFF
--- a/src/logsearch-config/Rakefile
+++ b/src/logsearch-config/Rakefile
@@ -15,10 +15,17 @@ task :build => :clean do
   puts `find target`
 end
 
-desc "Runs unit tests against filters & dashboards"
+desc "Runs tests against filters"
 task :test, [:rspec_files] => :build do |t, args|
   args.with_defaults(:rspec_files => "$(find test -name *spec.rb)")
   puts "===> Testing ..."
+  sh %Q[ vendor/logstash/bin/rspec #{args[:rspec_files]} --colour ]
+end
+
+desc "Runs integration tests against filters"
+task :itest, [:rspec_files] => :build do |t, args|
+  args.with_defaults(:rspec_files => "$(find test -name *it-spec.rb)")
+  puts "===> Integration Testing ..."
   sh %Q[ vendor/logstash/bin/rspec #{args[:rspec_files]} --colour ]
 end
 

--- a/src/logsearch-config/bin/itest
+++ b/src/logsearch-config/bin/itest
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BASE_DIR=$(cd $SCRIPT_DIR/.. ; pwd)
+
+cd $BASE_DIR
+
+bin/build
+rake itest["$1"]

--- a/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/firehose.conf
@@ -84,20 +84,8 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
         # ------------- common fields ------------------
 
-        # @input
+        # override @source.component, set @source.name & @source.instance
         mutate {
-          add_field => { "@input" => "%{@type}" }
-        }
-
-        # @shipper
-        mutate {
-          replace => { "[@shipper][priority]" => "%{syslog_pri}" }
-          replace => { "[@shipper][name]" => "%{syslog_program}_%{[@type]}" }
-        }
-
-        # @source (component, instance, name, host) & @shipper
-        mutate {
-          rename => { "[host]" => "[@source][host]" }
           rename => { "[app][source_type]" => "[@source][component]" }
           rename => { "[app][source_instance]" => "[@source][instance]" }
         }
@@ -108,8 +96,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           convert => { "[@source][instance]" => "integer" }
         }
 
-        # --------- index, @type and tags -----------
-        # app index name
+        # override index
         mutate { replace => { "[@metadata][index]" => "app" } }
         if [@source][org] {
             mutate { replace => { "[@metadata][index]" => "%{[@metadata][index]}-%{[@source][org]}" } }
@@ -119,11 +106,13 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
             mutate { lowercase => [ "[@metadata][index]" ] }
         }
 
+        # override @type and tags
         mutate {
           replace => { "@type" => "%{[app][event_type]}" }
           remove_field => "[app][event_type]"
           add_tag => [ "app" ]
         }
+
         # ----------- special cases processing -------------
         # ----------------------------
         # Special Case - Metrics logs |

--- a/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/haproxy.conf
@@ -40,7 +40,7 @@ if [@type] in ["syslog_cf", "relp_cf"] and [syslog_program] == "haproxy" {
         }
     }
 
-    # -------- specific @source.component, type, tags ----------
+    # -------- override @source.component, type, tags ----------
     mutate {
       replace => { "[@source][component]" => "haproxy" } # specific value
       replace => { "@type" => "haproxy_cf" }

--- a/src/logsearch-config/src/logstash-filters/snippets/platform.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform.conf
@@ -2,58 +2,34 @@ if [@type] in ["syslog", "relp"] and [syslog_program] != "doppler" {
 
     # Try parsing with default CF format (metron agent format)
 
-    if( [syslog_program] == "haproxy" ) {
-        mutate {
-          rename => { "[haproxy][message]" => "@message"}
-        }
-    }
-
     grok {
       match => [ "@message", "(?:\[job=%{NOTSPACE:jobname}|-) +(?:index=%{NOTSPACE:jobindex}\]|-)%{SPACE}%{GREEDYDATA:@message}" ]
       overwrite => [ "@message" ] # @message
       tag_on_failure => "fail/cloudfoundry/platform/grok"
     }
 
-    # ------------- common fields ------------------
-
-    # @input
-    mutate {
-      add_field => { "@input" => "%{@type}" }
-    }
-
-    # @shipper
-    mutate {
-      replace => { "[@shipper][priority]" => "%{syslog_pri}" }
-      replace => { "[@shipper][name]" => "%{syslog_program}_%{[@type]}" }
-    }
-
-    # @source (component, host)
-    mutate {
-      add_field => { "[@source][component]" => "%{syslog_program}" } # @source.component
-      rename => { "[host]" => "[@source][host]" }
-    }
-
     if !("fail/cloudfoundry/platform/grok" in [tags]) {
 
-        # @source.name and @source.instance
+        # ------------- common fields ------------------
+
+        # @source.name & @source.instance
         mutate {
           add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
-        }
-        mutate {
-          convert => { "jobindex" => "integer" }
         }
         mutate {
           rename => { "jobindex" => "[@source][instance]" }
           remove_field => "jobname"
         }
+        mutate {
+          convert => { "[@source][instance]" => "integer" }
+        }
         
-        # index, @type & tags
+        # override index, @type & tags
         mutate {
           replace => { "[@metadata][index]" => "platform" }
           replace => { "@type" => "%{[@type]}_cf" }
           add_tag => "cf"
         }
     }
-    # -------------------------------------------------
 
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/setup.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/setup.conf
@@ -1,5 +1,5 @@
 # Replace the unicode Null character \u0000 with \n
-# Ignore logs with empty msg
+# Drop useless logs
 mutate {
     gsub => [ "@message", '\u0000', ""]
 }
@@ -13,4 +13,22 @@ if ! [@metadata][index] {
     mutate {
         add_field => { "[@metadata][index]" => "unparsed" }
     }
+}
+
+# Set common fields (some of these fields are overridden in specific snippets)
+# @input
+mutate {
+  add_field => { "@input" => "%{@type}" }
+}
+
+# @shipper
+mutate {
+  replace => { "[@shipper][priority]" => "%{syslog_pri}" }
+  replace => { "[@shipper][name]" => "%{syslog_program}_%{[@type]}" }
+}
+
+# @source (component, host)
+mutate {
+  add_field => { "[@source][component]" => "%{syslog_program}" } # @source.component
+  rename => { "[host]" => "[@source][host]" }
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -22,13 +22,6 @@ if ![@level] and [syslog_severity_code] { # @level
     }
 }
 
-# Set [@source][component] (if not set yet)
-if ![@source][component] and [syslog_program] {
-    mutate {
-      add_field => { "[@source][component]" => "%{syslog_program}" } # specific value
-    }
-}
-
 # -- Cleanup unnecessary fields
 
 # Remove syslog_ fields

--- a/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/uaa.conf
@@ -52,7 +52,7 @@ if [@type] in ["syslog_cf", "relp_cf"] and [syslog_program] == "vcap.uaa" {
 
     }
 
-    # -------- specific @source.component, type, tags ----------
+    # -------- override @source.component, type, tags ----------
     mutate {
       replace => { "[@source][component]" => "uaa" } # specific value
       replace => { "@type" => "uaa_cf" }

--- a/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
@@ -17,14 +17,12 @@ if [@type] in ["syslog_cf", "relp_cf"] and ([syslog_program] != "vcap.uaa" and [
         }
         mutate {
           rename => { "[vcap][log_level]" => "@level" } # @level
-        }
-        mutate {
           rename => { "[vcap][message]" => "@message" } # @message
         }
 
     }
 
-    # -------- specific @source.component, type, tags ----------
+    # -------- override @source.component, type, tags ----------
     ruby {
       code => "event['[@source][component]'] = event['[@source][component]'][5..-1]" # minus "vcap." prefix
     }

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require 'test/filter_test_helpers'
+
+describe "App Integration Test spec" do
+
+  before(:all) do
+    load_filters <<-CONFIG
+      filter {
+        #{File.read("target/logstash-filters-default.conf")} # NOTE: we use already built config here
+      }
+    CONFIG
+  end
+
+  describe "checks fields" do
+
+    context "when msg in plain text format" do
+      when_parsing_log(
+          "@type" => "syslog",
+          "syslog_program" => "doppler",
+          "syslog_pri" => "6",
+          "host" => "bed08922-4734-4d62-9eba-3291aed1b8ce",
+          "@message" => "{\"cf_app_id\":\"31b928ee-4110-4e7b-996c-334c5d7ac2ac\",\"cf_app_name\":\"loggenerator\",\"cf_org_id\":\"9887ad0a-f9f7-449e-8982-76307bd17239\",\"cf_org_name\":\"admin\",\"cf_origin\":\"firehose\",\"cf_space_id\":\"59cf41f2-3a1d-42db-88e7-9540b02945e8\",\"cf_space_name\":\"demo\",\"event_type\":\"LogMessage\",\"level\":\"info\",\"message_type\":\"OUT\",\"msg\":\"{\\\"timestamp\\\":\\\"2016-07-08 10:00:40.073\\\",\\\"level\\\":\\\"INFO\\\",\\\"thread\\\":\\\"main\\\",\\\"logger\\\":\\\"com.altoros.LogGenerator\\\",\\\"message\\\":\\\"Some Message 7892,143\\\"}\",\"origin\":\"dea_logging_agent\",\"source_instance\":\"0\",\"source_type\":\"App\",\"time\":\"2016-07-08T10:00:40Z\",\"timestamp\":1467972040073786262}"
+      ) do
+
+        it "checks common fields" do
+          expect(subject["@input"]).to eq "syslog"
+          expect(subject["@shipper"]["priority"]).to eq "6"
+          expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
+          expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
+        end
+
+        it "checks common fields overridden by JSON" do
+          expect(subject["@source"]["component"]).to eq "App"
+        end
+
+        # TODO: verify other fields
+
+      end
+    end
+
+  end
+
+end

--- a/src/logsearch-config/test/logstash-filters/it/platform-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/platform-it-spec.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require 'test/filter_test_helpers'
+
+describe "Platform Integration Test spec" do
+
+  before(:all) do
+    load_filters <<-CONFIG
+      filter {
+        #{File.read("target/logstash-filters-default.conf")} # NOTE: we use already built config here
+      }
+    CONFIG
+  end
+
+  describe "checks fields" do
+
+    context "when @message in plain text format" do
+      when_parsing_log(
+          "@type" => "relp",
+          "syslog_program" => "vcap.consul-agent",
+          "syslog_pri" => "14",
+          "host" => "192.168.111.24:44577",
+          "@message" => "[job=nfs_z1 index=0]      2016/07/08 10:23:22 [WARN] agent: Check 'service:routing-api' is now critical"
+      ) do
+
+        it "checks common fields" do
+          expect(subject["@input"]).to eq "relp"
+          expect(subject["@shipper"]["priority"]).to eq "14"
+          expect(subject["@shipper"]["name"]).to eq "vcap.consul-agent_relp"
+          expect(subject["@source"]["host"]).to eq "192.168.111.24:44577"
+        end
+
+        it "checks common fields overridden" do
+          expect(subject["@source"]["component"]).to eq "consul-agent"
+        end
+
+        # TODO: verify other fields
+
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
1) Add support of integration tests. Integration tests run as part of all tests run and also can be started separately by executing bin/itest.
2) Add first integration tests (app and platform cases checking common fields).
3) Move parsing of common fields from snippets to setup.conf script. Snippets can override common fields with specific values if necessary.
4) Minor refactoring & comments.