### PR TITLE
Add mappings for not_analyzed .raw fields to be used in visualizations

### DIFF
--- a/generate_ingestor_manifest
+++ b/generate_ingestor_manifest
@@ -8,14 +8,11 @@ fi
 logsearch=$(dirname $0)/src/logsearch-config
 
 tmp1="/tmp/logstash_parser.yml"
-tmp2="/tmp/elasticsearch_app_mapping_config.yml"
-tmp3="/tmp/elasticsearch_platform_mapping_config.yml"
+tmp2="/tmp/elasticsearch_logs_template_config.yml"
 echo -e "properties:\n  logstash_parser:\n    filters: |">$tmp1
-echo -e "properties:\n  elasticsearch_config:\n    templates:\n    - <<: (( merge ))\n    - index_app_template: |">$tmp2
-echo -e "properties:\n  elasticsearch_config:\n    templates:\n    - index_platform_template: |">$tmp3
+echo -e "properties:\n  elasticsearch_config:\n    templates:\n    - <<: (( merge ))\n    - index_template: |">$tmp2
 ./$logsearch/bin/build >/dev/null 2>&1
 cat $logsearch/target/logstash-filters-default.conf | sed s/^/\ \ \ \ \ \ / >>$tmp1
-cat $logsearch/target/index-app-template.json | sed s/^/\ \ \ \ \ \ \ \ / >>$tmp2
-cat $logsearch/target/index-platform-template.json | sed s/^/\ \ \ \ \ \ \ \ / >>$tmp3
-spiff m $1 $tmp1 $tmp2 $tmp3
-rm $tmp1 $tmp2 $tmp3
+cat $logsearch/target/logs-template.json | sed s/^/\ \ \ \ \ \ \ \ / >>$tmp2
+spiff m $1 $tmp1 $tmp2
+rm $tmp1 $tmp2

--- a/src/logsearch-config/src/es-mappings/logs-template.json.erb
+++ b/src/logsearch-config/src/es-mappings/logs-template.json.erb
@@ -5,12 +5,56 @@
     "_default_" : {
       "dynamic_templates": [
         {
-          "string_not_analyzed": {
+          "string_not_analyzed__id_fields": {
             "match_pattern": "regex",
             "match": "^(\\S+_id)$",
             "match_mapping_type": "string",
             "mapping": {
               "type" : "string", "index" : "not_analyzed", "omit_norms" : true
+            }
+          }
+        },
+        {
+          "raw_for_string_significant__simple_fields": {
+            "match_pattern": "regex",
+            "match": "^(@level|@type|@input)$",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "multi_field",
+              "fields": {
+                "{name}": {
+                  "type": "string",
+                  "index": "analyzed",
+                  "omit_norms": true
+                },
+                "raw": {
+                  "type": "string",
+                  "index": "not_analyzed",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        },
+        {
+          "raw_for_string_significant__path_fields": {
+            "match_pattern": "regex",
+            "path_match": "^(@shipper.name|@source.*|log.*)$",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "multi_field",
+              "fields": {
+                "{name}": {
+                  "type": "string",
+                  "index": "analyzed",
+                  "omit_norms": true
+                },
+                "raw": {
+                  "type": "string",
+                  "index": "not_analyzed",
+                  "ignore_above": 256
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
The mappings set to create *.raw not_analyzed fields for significant string fields (those fields that are supposed to be used in visualizations, aggregations etc).