### PR TITLE
Add readme about packages sources

### DIFF
--- a/packages/cf-cli/README.md
+++ b/packages/cf-cli/README.md
@@ -1,0 +1,9 @@
+cf-cli-package
+============
+This repo is used for cf-cli packaging in BOSH deployments.
+
+The files can be downloaded from the following locations:
+
+| Filename | Download URL |
+| -------- | ------------ |
+| cf-cli_6.19.0_linux_x86-64.tgz | [github.com/cloudfoundry/cli/releases](https://s3.amazonaws.com/go-cli/releases/v6.19.0/cf-cli_6.19.0_linux_x86-64.tgz) |

--- a/packages/cf-kibana/README.md
+++ b/packages/cf-kibana/README.md
@@ -1,0 +1,9 @@
+kibana-package
+============
+This repo is used for kibana packaging in BOSH deployments.
+
+The files can be downloaded from the following locations:
+
+| Filename | Download URL |
+| -------- | ------------ |
+| kibana-4.4.2-linux-x64.tar.gz | [elastic.co](https://download.elastic.co/kibana/kibana/kibana-4.4.2-linux-x64.tar.gz) |

--- a/packages/golang/README.md
+++ b/packages/golang/README.md
@@ -1,0 +1,9 @@
+go-package
+============
+This repo is used for go packaging in BOSH deployments.
+
+The files can be downloaded from the following locations:
+
+| Filename | Download URL |
+| -------- | ------------ |
+| go1.6.2.linux-amd64.tar.gz | [golang.org](https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz) |

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -1,5 +1,4 @@
 set -e
 
-# golang.org/dl/
 tar xzf golang/go1.6.2.linux-amd64.tar.gz
 cp -R go/* ${BOSH_INSTALL_TARGET}


### PR DESCRIPTION
Add readme about packages sources in the same way as this done in major bosh projects. Here the example https://github.com/cloudfoundry/cf-release/tree/v238/packages/ruby-2.1.8