### PR TITLE
Add syslog-protocol property to firehose-to-syslog package

### DIFF
--- a/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/jobs/ingestor_cloudfoundry-firehose/spec
@@ -39,3 +39,6 @@ properties:
   syslog.port:
     description: port of the syslog drain
     default: 5514
+  syslog.protocol:
+    description: Syslog protocol (tcp/udp).
+    default: tcp

--- a/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -53,6 +53,7 @@ case $1 in
         <% if p("cloudfoundry.skip_ssl_validation") %>--skip-ssl-validation <% end %> \
         --user=<%= p("cloudfoundry.firehose_user") %> \
         --password=<%= p("cloudfoundry.firehose_password") %> \
+        --syslog-protocol=<%= p("syslog.protocol") %>\
         --syslog-server=<%= p("syslog.host") %>:<%= p("syslog.port") %>\
         --events=<%= p("cloudfoundry.firehose_events") %> \
         --boltdb-path=$TMP_DIR/firehose-to-syslog.cache.db \


### PR DESCRIPTION
Hi @axelaris 
Firehose-to-syslog now supports different syslog protocols, this change was introduced in the next commit https://github.com/cloudfoundry-community/firehose-to-syslog/commit/10682878d02c225ce6392b2ea2e176e8a858cf6f. I updated `ingestor_cloudfoundry-firehose` job to support this property.
By default i set to still use tcp protocol.
Thanks!