### PR TITLE
Remove unused logsearch-boshrelease submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "src/firehose-to-syslog"]
 	path = src/firehose-to-syslog
 	url = https://github.com/cloudfoundry-community/firehose-to-syslog.git
-[submodule "src/logsearch-config/vendor/logsearch-boshrelease"]
-	path = src/logsearch-config/vendor/logsearch-boshrelease
-	url = https://github.com/logsearch/logsearch-boshrelease.git

--- a/src/logsearch-config/bin/build
+++ b/src/logsearch-config/bin/build
@@ -8,5 +8,3 @@ BASE_DIR=$(cd $SCRIPT_DIR/.. ; pwd)
 cd $BASE_DIR
 
 rake build
-
-vendor/logsearch-boshrelease/src/logsearch-config/bin/build


### PR DESCRIPTION
Hi @axelaris 
I prefer to delete unused `logsearch-boshrelease` submodule. Since we are running all tests against `logsearch-for-cloudfoundry` filters we don't need to build logsearch-boshrelease filters using `vendor/logsearch-boshrelease/src/logsearch-config/bin/build`.