### PR TITLE
Disable kibana app logs by default

### DIFF
--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -42,6 +42,9 @@ properties:
     default: 9200
   cf-kibana.api_security_group:
     description: "CF security group with API access"
+  cf-kibana.logging_quiet:
+    description: "Set to true to suppress all logging output other than error messages"
+    default: true
 
   cloudfoundry.api_endpoint:
     description: "The CF API URL"

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -74,7 +74,7 @@ kibana.index: ".kibana"
 # logging.silent: false
 
 # Set the value of this setting to true to suppress all logging output other than error messages.
-# logging.quiet: false
+logging.quiet: <%= p("cf-kibana.logging_quiet") %>
 
 # Set the value of this setting to true to log all events, including system usage information
 # and all requests.


### PR DESCRIPTION
Hi @axelaris 
After discussion with @hannayurkevich we decide to disable Kibana application logs by default.
I set `logging.silent: true` by default, here the reference to Kibana server properties:
https://www.elastic.co/guide/en/kibana/current/kibana-server-properties.html
Thanks!