### PR TITLE
Uppercase [@source][component] in app logs

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app-log.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-log.conf
@@ -2,7 +2,7 @@
 # Special Case - application logs |
 # --------------------------------
 # Parse application logs based on msg format (mark unknown format with [unknown_msg_format] tag)
-if([@type] == "LogMessage" and [@source][component] == "App") {
+if([@type] == "LogMessage" and [@source][component] == "APP") {
 
   mutate {
     add_tag => [ "log" ]

--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -78,6 +78,9 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           rename => { "[app][source_type]" => "[@source][component]" }
           rename => { "[app][source_instance]" => "[@source][instance]" }
         }
+        mutate {
+          uppercase => [ "[@source][component]" ] # we rely on component value in next scripts so let's uppercase it
+        }
 
         # override index
         mutate { replace => { "[@metadata][index]" => "app" } }

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'test/filter_test_helpers'
+require 'test/logstash-filters/it_app_helper'
 
 describe "App Integration Test" do
 
@@ -9,236 +10,193 @@ describe "App Integration Test" do
         #{File.read("target/logstash-filters-default.conf")} # NOTE: we use already built config here
       }
     CONFIG
+
   end
 
-  describe "when message is app log" do
+  # init app event (dummy)
+  app_event_dummy = {"@type" => "syslog",
+               "syslog_program" => "doppler",
+               "syslog_pri" => "6",
+               "syslog_severity_code" => 3,
+               "host" => "bed08922-4734-4d62-9eba-3291aed1b8ce",
+               "@message" => "Dummy message"}
 
-    context "(unknown msg format)" do
-      when_parsing_log(
-          "@type" => "syslog",
-          "syslog_program" => "doppler",
-          "syslog_pri" => "6",
-          "syslog_severity_code" => 3,
-          "host" => "bed08922-4734-4d62-9eba-3291aed1b8ce",
-          "@message" => "{\"cf_app_id\":\"31b928ee-4110-4e7b-996c-334c5d7ac2ac\",\"cf_app_name\":\"loggenerator\",\"cf_org_id\":\"9887ad0a-f9f7-449e-8982-76307bd17239\",\"cf_org_name\":\"admin\",\"cf_origin\":\"firehose\",\"cf_space_id\":\"59cf41f2-3a1d-42db-88e7-9540b02945e8\",\"cf_space_name\":\"demo\",\"event_type\":\"LogMessage\",\"level\":\"info\",\"message_type\":\"OUT\"," +
-              "\"msg\":\"Some Message\"," + # unknown format
-              "\"origin\":\"dea_logging_agent\",\"source_instance\":\"0\",\"source_type\":\"App\",\"time\":\"2016-07-08T10:00:40Z\",\"timestamp\":1467972040073786262}"
-      ) do
+  describe "when type=LogMessage, component=App" do
 
-        # no parsing errors
-        it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/app/json" }
+    # NOTE: below tests are pretty the same but sample message is different
+    # in case of Diego CF and Dea.
 
-        # fields
-        it "should set common fields" do
-          expect(subject["@input"]).to eq "syslog"
-          expect(subject["@shipper"]["priority"]).to eq "6"
-          expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
-          expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
-          expect(subject["@source"]["name"]).to eq "App/0"
-          expect(subject["@source"]["instance"]).to eq 0
+    describe "with Dea CF" do
 
-          expect(subject["@metadata"]["index"]).to eq "app-admin-demo"
+      builder = MessagePayloadBuilder.new
+          .origin("dea_logging_agent") # dea
+          .job("runner_z1") # dea job
+          .event_type("LogMessage")
+          .source_type("App") # NOTE: Dea sets 'App' source_type as lowercase
+          .level("info")
+
+      context "(unknown msg format)" do
+
+        app_message_payload = builder.clone
+                              .msg("Some text msg") # unknown msg format
+                              .build
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
+
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "INFO", "Some text msg")
+
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to include "unknown_msg_format" }
         end
-
-        it "should override common fields" do
-          expect(subject["@source"]["component"]).to eq "App"
-          expect(subject["@type"]).to eq "LogMessage"
-          expect(subject["@tags"]).to include "app"
-        end
-
-        it "should set app specific fields" do
-          expect(subject["@source"]["app"]).to eq "loggenerator"
-          expect(subject["@source"]["app_id"]).to eq "31b928ee-4110-4e7b-996c-334c5d7ac2ac"
-          expect(subject["@source"]["space"]).to eq "demo"
-          expect(subject["@source"]["space_id"]).to eq "59cf41f2-3a1d-42db-88e7-9540b02945e8"
-          expect(subject["@source"]["org"]).to eq "admin"
-          expect(subject["@source"]["org_id"]).to eq "9887ad0a-f9f7-449e-8982-76307bd17239"
-          expect(subject["@source"]["origin"]).to eq "dea_logging_agent"
-          expect(subject["@source"]["message_type"]).to eq "OUT"
-        end
-
-        it "should set mandatory fields" do
-          expect(subject["@message"]).to eq "Some Message"
-          expect(subject["@level"]).to eq "INFO"
-        end
-
-        # format-specific
-        it { expect(subject["@tags"]).to include "unknown_msg_format" }
-
       end
+
+      context "(JSON msg)" do
+
+        app_message_payload = builder.clone
+                                  .msg("{\\\"timestamp\\\":\\\"2016-07-15 13:20:16.954\\\"," +
+                                           "\\\"level\\\":\\\"ERROR\\\"," +
+                                           "\\\"thread\\\":\\\"main\\\",\\\"logger\\\":\\\"com.abc.LogGenerator\\\"," +
+                                           "\\\"message\\\":\\\"Some json msg\\\"}") # JSON msg
+                                  .build
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
+
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "ERROR", "Some json msg")
+
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to include "log" }
+          it { expect(subject["@tags"]).not_to include "unknown_msg_format" }
+
+          it { expect(subject["log"]["timestamp"]).to eq "2016-07-15 13:20:16.954" }
+          it { expect(subject["log"]["thread"]).to eq "main" }
+          it { expect(subject["log"]["logger"]).to eq "com.abc.LogGenerator" }
+        end
+      end
+
+      context "([CONTAINER] log)" do
+        app_message_payload = builder.clone
+                              .msg("[CONTAINER] org.apache.catalina.startup.Catalina    DEBUG    Server startup in 9775 ms")
+                              .build # [CONTAINER] msg
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
+
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
+                        "DEBUG", "Server startup in 9775 ms")
+
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
+          it { expect(subject["log"]["logger"]).to eq "[CONTAINER] org.apache.catalina.startup.Catalina" }
+        end
+      end
+
+      context "(Logback status log)" do
+        app_message_payload = builder.clone
+                              .msg("16:41:17,033 |-DEBUG in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN")
+                              .build # Logback status msg
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
+
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
+                        "DEBUG", "Setting level of ROOT logger to WARN")
+
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
+          it { expect(subject["log"]["logger"]).to eq "ch.qos.logback.classic.joran.action.RootLoggerAction" }
+        end
+      end
+
     end
 
-    context "(JSON msg)" do
-      when_parsing_log(
-          "@type" => "syslog",
-          "syslog_program" => "doppler",
-          "syslog_pri" => "6",
-          "syslog_severity_code" => 3,
-          "host" => "bed08922-4734-4d62-9eba-3291aed1b8ce",
-          "@message" => "{\"cf_app_id\":\"31b928ee-4110-4e7b-996c-334c5d7ac2ac\",\"cf_app_name\":\"loggenerator\",\"cf_org_id\":\"9887ad0a-f9f7-449e-8982-76307bd17239\",\"cf_org_name\":\"admin\",\"cf_origin\":\"firehose\",\"cf_space_id\":\"59cf41f2-3a1d-42db-88e7-9540b02945e8\",\"cf_space_name\":\"demo\",\"event_type\":\"LogMessage\",\"level\":\"info\",\"message_type\":\"OUT\"," +
-              # JSON msg
-              "\"msg\":\"{\\\"timestamp\\\":\\\"2016-07-15 13:20:16.954\\\",\\\"level\\\":\\\"ERROR\\\",\\\"thread\\\":\\\"main\\\",\\\"logger\\\":\\\"com.abc.LogGenerator\\\",\\\"message\\\":\\\"Some message\\\"}\",\"origin\":\"dea_logging_agent\",\"source_instance\":\"0\",\"source_type\":\"App\",\"time\":\"2016-07-08T10:00:40Z\",\"timestamp\":1467972040073786262}"
-      ) do
+    describe "with Diego CF" do
 
-        # no parsing errors
-        it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/app/json" }
+      builder = MessagePayloadBuilder.new
+                    .origin("rep") # diego
+                    .job("cell_z1") # diego job
+                    .event_type("LogMessage")
+                    .source_type("APP") # NOTE: Diego sets 'APP' source_type as uppercase
+                    .level("info")
 
-        # fields
-        it "should set common fields" do
-          expect(subject["@input"]).to eq "syslog"
-          expect(subject["@shipper"]["priority"]).to eq "6"
-          expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
-          expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
-          expect(subject["@source"]["name"]).to eq "App/0"
-          expect(subject["@source"]["instance"]).to eq 0
+      context "(unknown msg format)" do
 
-          expect(subject["@metadata"]["index"]).to eq "app-admin-demo"
+        app_message_payload = builder.clone
+                                  .msg("Some text msg") # unknown msg format
+                                  .build
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
+
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "INFO", "Some text msg")
+
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to include "unknown_msg_format" }
         end
-
-        it "should override common fields" do
-          expect(subject["@source"]["component"]).to eq "App"
-          expect(subject["@type"]).to eq "LogMessage"
-          expect(subject["@tags"]).to include "app"
-        end
-
-        it "should set app specific fields" do
-          expect(subject["@source"]["app"]).to eq "loggenerator"
-          expect(subject["@source"]["app_id"]).to eq "31b928ee-4110-4e7b-996c-334c5d7ac2ac"
-          expect(subject["@source"]["space"]).to eq "demo"
-          expect(subject["@source"]["space_id"]).to eq "59cf41f2-3a1d-42db-88e7-9540b02945e8"
-          expect(subject["@source"]["org"]).to eq "admin"
-          expect(subject["@source"]["org_id"]).to eq "9887ad0a-f9f7-449e-8982-76307bd17239"
-          expect(subject["@source"]["origin"]).to eq "dea_logging_agent"
-          expect(subject["@source"]["message_type"]).to eq "OUT"
-        end
-
-        # format-specific
-        it { expect(subject["@tags"]).to include "log" }
-        it { expect(subject["@tags"]).not_to include "unknown_msg_format" }
-
-        it "should set fields from JSON" do
-          expect(subject["@message"]).to eq "Some message"
-          expect(subject["@level"]).to eq "ERROR"
-          expect(subject["log"]["timestamp"]).to eq "2016-07-15 13:20:16.954"
-          expect(subject["log"]["thread"]).to eq "main"
-          expect(subject["log"]["logger"]).to eq "com.abc.LogGenerator"
-        end
-
       end
-    end
 
-    context "([CONTAINER] log)" do
-      when_parsing_log(
-          "@type" => "syslog",
-          "syslog_program" => "doppler",
-          "syslog_pri" => "6",
-          "syslog_severity_code" => 3,
-          "host" => "bed08922-4734-4d62-9eba-3291aed1b8ce",
-          "@message" => "{\"cf_app_id\":\"31b928ee-4110-4e7b-996c-334c5d7ac2ac\",\"cf_app_name\":\"loggenerator\",\"cf_org_id\":\"9887ad0a-f9f7-449e-8982-76307bd17239\",\"cf_org_name\":\"admin\",\"cf_origin\":\"firehose\",\"cf_space_id\":\"59cf41f2-3a1d-42db-88e7-9540b02945e8\",\"cf_space_name\":\"demo\",\"event_type\":\"LogMessage\",\"level\":\"info\",\"message_type\":\"OUT\"," +
-              # [CONTAINER]... msg
-              "\"msg\":\"[CONTAINER] org.apache.catalina.startup.Catalina               DEBUG    Server startup in 9775 ms\",\"origin\":\"dea_logging_agent\",\"source_instance\":\"0\",\"source_type\":\"App\",\"time\":\"2016-07-08T10:00:40Z\",\"timestamp\":1467972040073786262}"
-      ) do
+      context "(JSON msg)" do
 
-        # no parsing errors
-        it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/app/json" }
+        app_message_payload = builder.clone
+                                  .msg("{\\\"timestamp\\\":\\\"2016-07-15 13:20:16.954\\\"," +
+                                           "\\\"level\\\":\\\"ERROR\\\"," +
+                                           "\\\"thread\\\":\\\"main\\\",\\\"logger\\\":\\\"com.abc.LogGenerator\\\"," +
+                                           "\\\"message\\\":\\\"Some json msg\\\"}") # JSON msg
+                                  .build
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
 
-        # fields
-        it "should set common fields" do
-          expect(subject["@input"]).to eq "syslog"
-          expect(subject["@shipper"]["priority"]).to eq "6"
-          expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
-          expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
-          expect(subject["@source"]["name"]).to eq "App/0"
-          expect(subject["@source"]["instance"]).to eq 0
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "ERROR", "Some json msg")
 
-          expect(subject["@metadata"]["index"]).to eq "app-admin-demo"
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to include "log" }
+          it { expect(subject["@tags"]).not_to include "unknown_msg_format" }
+
+          it { expect(subject["log"]["timestamp"]).to eq "2016-07-15 13:20:16.954" }
+          it { expect(subject["log"]["thread"]).to eq "main" }
+          it { expect(subject["log"]["logger"]).to eq "com.abc.LogGenerator" }
         end
-
-        it "should override common fields" do
-          expect(subject["@source"]["component"]).to eq "App"
-          expect(subject["@type"]).to eq "LogMessage"
-          expect(subject["@tags"]).to include "app"
-        end
-
-        it "should set app specific fields" do
-          expect(subject["@source"]["app"]).to eq "loggenerator"
-          expect(subject["@source"]["app_id"]).to eq "31b928ee-4110-4e7b-996c-334c5d7ac2ac"
-          expect(subject["@source"]["space"]).to eq "demo"
-          expect(subject["@source"]["space_id"]).to eq "59cf41f2-3a1d-42db-88e7-9540b02945e8"
-          expect(subject["@source"]["org"]).to eq "admin"
-          expect(subject["@source"]["org_id"]).to eq "9887ad0a-f9f7-449e-8982-76307bd17239"
-          expect(subject["@source"]["origin"]).to eq "dea_logging_agent"
-          expect(subject["@source"]["message_type"]).to eq "OUT"
-        end
-
-        # format-specific
-        it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
-
-        it "should set fields from 'grok'" do
-          expect(subject["@message"]).to eq "Server startup in 9775 ms"
-          expect(subject["@level"]).to eq "DEBUG"
-          expect(subject["log"]["logger"]).to eq "[CONTAINER] org.apache.catalina.startup.Catalina"
-        end
-
       end
-    end
 
-    context "(Logback status log)" do
-      when_parsing_log(
-          "@type" => "syslog",
-          "syslog_program" => "doppler",
-          "syslog_pri" => "6",
-          "syslog_severity_code" => 3,
-          "host" => "bed08922-4734-4d62-9eba-3291aed1b8ce",
-          "@message" => "{\"cf_app_id\":\"31b928ee-4110-4e7b-996c-334c5d7ac2ac\",\"cf_app_name\":\"loggenerator\",\"cf_org_id\":\"9887ad0a-f9f7-449e-8982-76307bd17239\",\"cf_org_name\":\"admin\",\"cf_origin\":\"firehose\",\"cf_space_id\":\"59cf41f2-3a1d-42db-88e7-9540b02945e8\",\"cf_space_name\":\"demo\",\"event_type\":\"LogMessage\",\"level\":\"info\",\"message_type\":\"OUT\"," +
-              # Logback status log
-              "\"msg\":\"16:41:17,033 |-DEBUG in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN\",\"origin\":\"dea_logging_agent\",\"source_instance\":\"0\",\"source_type\":\"App\",\"time\":\"2016-07-08T10:00:40Z\",\"timestamp\":1467972040073786262}"
-      ) do
+      context "([CONTAINER] log)" do
+        app_message_payload = builder.clone
+                                  .msg("[CONTAINER] org.apache.catalina.startup.Catalina    DEBUG    Server startup in 9775 ms")
+                                  .build # [CONTAINER] msg
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
 
-        # no parsing errors
-        it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/app/json" }
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
+                        "DEBUG", "Server startup in 9775 ms")
 
-        # fields
-        it "should set common fields" do
-          expect(subject["@input"]).to eq "syslog"
-          expect(subject["@shipper"]["priority"]).to eq "6"
-          expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
-          expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
-          expect(subject["@source"]["name"]).to eq "App/0"
-          expect(subject["@source"]["instance"]).to eq 0
-
-          expect(subject["@metadata"]["index"]).to eq "app-admin-demo"
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
+          it { expect(subject["log"]["logger"]).to eq "[CONTAINER] org.apache.catalina.startup.Catalina" }
         end
-
-        it "should override common fields" do
-          expect(subject["@source"]["component"]).to eq "App"
-          expect(subject["@type"]).to eq "LogMessage"
-          expect(subject["@tags"]).to include "app"
-        end
-
-        it "should set app specific fields" do
-          expect(subject["@source"]["app"]).to eq "loggenerator"
-          expect(subject["@source"]["app_id"]).to eq "31b928ee-4110-4e7b-996c-334c5d7ac2ac"
-          expect(subject["@source"]["space"]).to eq "demo"
-          expect(subject["@source"]["space_id"]).to eq "59cf41f2-3a1d-42db-88e7-9540b02945e8"
-          expect(subject["@source"]["org"]).to eq "admin"
-          expect(subject["@source"]["org_id"]).to eq "9887ad0a-f9f7-449e-8982-76307bd17239"
-          expect(subject["@source"]["origin"]).to eq "dea_logging_agent"
-          expect(subject["@source"]["message_type"]).to eq "OUT"
-        end
-
-        # format-specific
-        it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
-
-        it "should set fields from 'grok'" do
-          expect(subject["@message"]).to eq "Setting level of ROOT logger to WARN"
-          expect(subject["@level"]).to eq "DEBUG"
-          expect(subject["log"]["logger"]).to eq "ch.qos.logback.classic.joran.action.RootLoggerAction"
-        end
-
       end
+
+      context "(Logback status log)" do
+        app_message_payload = builder.clone
+                                  .msg("16:41:17,033 |-DEBUG in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN")
+                                  .build # Logback status msg
+        sample_event = app_event_dummy.clone
+        sample_event["@message"] = construct_app_message(app_message_payload)
+
+        when_parsing_log(sample_event) do
+          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
+                        "DEBUG", "Setting level of ROOT logger to WARN")
+
+          # verify format-specific fields
+          it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
+          it { expect(subject["log"]["logger"]).to eq "ch.qos.logback.classic.joran.action.RootLoggerAction" }
+        end
+      end
+
     end
 
   end
+
 
 end

--- a/src/logsearch-config/test/logstash-filters/it_app_helper.rb
+++ b/src/logsearch-config/test/logstash-filters/it_app_helper.rb
@@ -1,0 +1,105 @@
+# encoding: utf-8
+class MessagePayload
+  attr_accessor :origin, :job, :event_type, :source_type, :msg, :level
+end
+
+class MessagePayloadBuilder
+  attr_accessor :message_payload
+
+  def initialize
+    @message_payload = MessagePayload.new
+  end
+
+  def build
+    @message_payload
+  end
+
+  def job(job)
+    @message_payload.job = job
+    self
+  end
+
+  def origin(origin)
+    @message_payload.origin = origin
+    self
+  end
+
+  def event_type(event_type)
+    @message_payload.event_type = event_type
+    self
+  end
+
+  def source_type(source_type)
+    @message_payload.source_type = source_type
+    self
+  end
+
+  def msg(msg)
+    @message_payload.msg = msg
+    self
+  end
+
+  def level(level)
+    @message_payload.level = level
+    self
+  end
+end
+
+def construct_app_message (message_payload)
+  '{
+    "cf_app_id":"31b928ee-4110-4e7b-996c-334c5d7ac2ac", "cf_app_name":"loggenerator",
+    "cf_org_id":"9887ad0a-f9f7-449e-8982-76307bd17239", "cf_org_name":"admin",
+    "cf_origin":"firehose",
+    "cf_space_id":"59cf41f2-3a1d-42db-88e7-9540b02945e8","cf_space_name":"demo",
+    "deployment":"cf-full",
+    "event_type":"' + message_payload.event_type + '",
+    "index":"0","ip":"192.168.111.35","job":"' + message_payload.job + '",
+    "level":"info",
+    "message_type":"OUT",
+    "msg":"' + message_payload.msg + '" ,
+    "origin":"' + message_payload.origin + '" ,
+    "source_instance":"0",
+    "source_type":"' + message_payload.source_type + '",
+    "time":"2016-07-08T10:00:40Z", "timestamp":1467972040073786262 }'
+end
+
+def verify_fields (expected_origin, expected_type, expected_source, expected_level, expected_message)
+
+  # no parsing errors
+  it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/app/json" }
+
+  # fields
+  it "should set common fields" do
+    expect(subject["@input"]).to eq "syslog"
+    expect(subject["@shipper"]["priority"]).to eq "6"
+    expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
+    expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
+    expect(subject["@source"]["name"]).to eq (expected_source + "/0")
+    expect(subject["@source"]["instance"]).to eq 0
+
+    expect(subject["@metadata"]["index"]).to eq "app-admin-demo"
+  end
+
+  it "should override common fields" do
+    expect(subject["@source"]["component"]).to eq expected_source
+    expect(subject["@type"]).to eq expected_type
+    expect(subject["@tags"]).to include "app"
+  end
+
+  it "should set app specific fields" do
+    expect(subject["@source"]["app"]).to eq "loggenerator"
+    expect(subject["@source"]["app_id"]).to eq "31b928ee-4110-4e7b-996c-334c5d7ac2ac"
+    expect(subject["@source"]["space"]).to eq "demo"
+    expect(subject["@source"]["space_id"]).to eq "59cf41f2-3a1d-42db-88e7-9540b02945e8"
+    expect(subject["@source"]["org"]).to eq "admin"
+    expect(subject["@source"]["org_id"]).to eq "9887ad0a-f9f7-449e-8982-76307bd17239"
+    expect(subject["@source"]["origin"]).to eq expected_origin
+    expect(subject["@source"]["message_type"]).to eq "OUT"
+  end
+
+  it "should set mandatory fields" do
+    expect(subject["@message"]).to eq expected_message
+    expect(subject["@level"]).to eq expected_level
+  end
+
+end

--- a/src/logsearch-config/test/logstash-filters/snippets/app-log-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/app-log-spec.rb
@@ -11,85 +11,151 @@ describe "app-log.conf" do
     CONFIG
   end
 
-  describe "when message is JSON format" do
-    context "(general)" do
+  describe "when message is" do
+
+    describe "JSON format" do
+      context "(general)" do
+        when_parsing_log(
+            "@type" => "LogMessage", # good type
+            "@source" => { "component" => "APP" }, # good component
+            "@level" => "SOME LEVEL",
+            # JSON format (general)
+            "@message" => "{\"timestamp\":\"2016-07-15 13:20:16.954\",\"level\":\"INFO\",\"thread\":\"main\",\"logger\":\"com.abc.LogGenerator\",\"message\":\"Some message\"}"
+        ) do
+
+          # log tag only (no fail tags)
+          it { expect(subject["tags"]).to eq ["log"] }
+
+          it "should override fields from JSON" do
+            expect(subject["@message"]).to eq "Some message"
+            expect(subject["@level"]).to eq "INFO"
+            expect(subject["log"]["message"]).to be_nil
+            expect(subject["log"]["level"]).to be_nil
+          end
+
+          it "should set [log] fields from JSON" do
+            expect(subject["log"]["timestamp"]).to eq "2016-07-15 13:20:16.954"
+            expect(subject["log"]["thread"]).to eq "main"
+            expect(subject["log"]["logger"]).to eq "com.abc.LogGenerator"
+          end
+
+        end
+      end
+
+      context "(with exception)" do
+        when_parsing_log(
+            "@type" => "LogMessage",
+            "@source" => { "component" => "APP" },
+            "@level" => "SOME LEVEL",
+            # JSON format (with exception)
+            "@message" => "{\"message\":\"Some error\", \"exception\":\"Some exception\"}"
+        ) do
+
+          it "should append exception to message" do
+            expect(subject["@message"]).to eq "Some error
+Some exception"
+            expect(subject["log"]).to be_empty
+          end
+
+        end
+      end
+
+      context "(invalid)" do
+        when_parsing_log(
+            "@type" => "LogMessage",
+            "@source" => { "component" => "APP" },
+            "@level" => "SOME LEVEL",
+            "@message" => "{\"message\":\"Some message\", }" # invalid JSON
+        ) do
+
+          # log tag only & unknown_message_format tag
+          it { expect(subject["tags"]).to eq ["log", "unknown_msg_format"] }
+
+          it "should not override fields" do
+            expect(subject["@message"]).to eq "{\"message\":\"Some message\", }"
+            expect(subject["@level"]).to eq "SOME LEVEL"
+          end
+
+        end
+      end
+
+      context "(empty)" do
+        when_parsing_log(
+            "@type" => "LogMessage",
+            "@source" => { "component" => "APP" },
+            "@level" => "SOME LEVEL",
+            "@message" => "{}" # empty JSON
+        ) do
+
+          # log tag only & unknown_message_format tag
+          it { expect(subject["tags"]).to eq ["log", "unknown_msg_format"] }
+
+          it "should not override fields" do
+            expect(subject["@message"]).to eq "{}"
+            expect(subject["@level"]).to eq "SOME LEVEL"
+          end
+
+        end
+      end
+
+    end
+
+    describe "[CONTAINER] log" do
       when_parsing_log(
           "@type" => "LogMessage", # good type
-          "@source" => { "component" => "App" }, # good component
+          "@source" => { "component" => "APP" }, # good component
           "@level" => "SOME LEVEL",
-          # JSON format (general)
-          "@message" => "{\"timestamp\":\"2016-07-15 13:20:16.954\",\"level\":\"INFO\",\"thread\":\"main\",\"logger\":\"com.abc.LogGenerator\",\"message\":\"Some message\"}"
+          # [CONTAINER] log
+          "@message" => "[CONTAINER] org.apache.catalina.startup.Catalina               INFO    Server startup in 9775 ms"
       ) do
 
         # log tag only (no fail tags)
         it { expect(subject["tags"]).to eq ["log"] }
 
-        it "should override fields from JSON" do
-          expect(subject["@message"]).to eq "Some message"
+        it "should set fields from 'grok'" do
+          expect(subject["@message"]).to eq "Server startup in 9775 ms"
           expect(subject["@level"]).to eq "INFO"
-          expect(subject["log"]["message"]).to be_nil
-          expect(subject["log"]["level"]).to be_nil
-        end
-
-        it "should set [log] fields from JSON" do
-          expect(subject["log"]["timestamp"]).to eq "2016-07-15 13:20:16.954"
-          expect(subject["log"]["thread"]).to eq "main"
-          expect(subject["log"]["logger"]).to eq "com.abc.LogGenerator"
+          expect(subject["log"]["logger"]).to eq "[CONTAINER] org.apache.catalina.startup.Catalina"
         end
 
       end
     end
 
-    context "(with exception)" do
+    describe "Logback status log" do
       when_parsing_log(
-          "@type" => "LogMessage",
-          "@source" => { "component" => "App" },
+          "@type" => "LogMessage", # good type
+          "@source" => { "component" => "APP" }, # good component
           "@level" => "SOME LEVEL",
-          # JSON format (with exception)
-          "@message" => "{\"message\":\"Some error\", \"exception\":\"Some exception\"}"
+          # Logback status log
+          "@message" => "16:41:17,033 |-DEBUG in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN"
       ) do
 
-        it "should append exception to message" do
-          expect(subject["@message"]).to eq "Some error
-Some exception"
-          expect(subject["log"]).to be_empty
+        # log tag only (no fail tags)
+        it { expect(subject["tags"]).to eq ["log"] }
+
+        it "should set fields from 'grok'" do
+          expect(subject["@message"]).to eq "Setting level of ROOT logger to WARN"
+          expect(subject["@level"]).to eq "DEBUG"
+          expect(subject["log"]["logger"]).to eq "ch.qos.logback.classic.joran.action.RootLoggerAction"
         end
 
       end
     end
 
-    context "(invalid)" do
+    describe "unknown format" do
+
       when_parsing_log(
-          "@type" => "LogMessage",
-          "@source" => { "component" => "App" },
+          "@type" => "LogMessage", # good type
+          "@source" => { "component" => "APP" }, # good component
           "@level" => "SOME LEVEL",
-          "@message" => "{\"message\":\"Some message\", }" # invalid JSON
+          "@message" => "Some Message" # unknown format
       ) do
 
-        # log tag only & unknown_message_format tag
+        # log tag, unknown_msg_format tag
         it { expect(subject["tags"]).to eq ["log", "unknown_msg_format"] }
 
-        it "should not override fields" do
-          expect(subject["@message"]).to eq "{\"message\":\"Some message\", }"
-          expect(subject["@level"]).to eq "SOME LEVEL"
-        end
-
-      end
-    end
-
-    context "(empty)" do
-      when_parsing_log(
-          "@type" => "LogMessage",
-          "@source" => { "component" => "App" },
-          "@level" => "SOME LEVEL",
-          "@message" => "{}" # empty JSON
-      ) do
-
-        # log tag only & unknown_message_format tag
-        it { expect(subject["tags"]).to eq ["log", "unknown_msg_format"] }
-
-        it "should not override fields" do
-          expect(subject["@message"]).to eq "{}"
+        it "should keep fields" do
+          expect(subject["@message"]).to eq "Some Message"
           expect(subject["@level"]).to eq "SOME LEVEL"
         end
 
@@ -98,75 +164,13 @@ Some exception"
 
   end
 
-  describe "when message is [CONTAINER] log" do
-    when_parsing_log(
-        "@type" => "LogMessage", # good type
-        "@source" => { "component" => "App" }, # good component
-        "@level" => "SOME LEVEL",
-        # [CONTAINER] log
-        "@message" => "[CONTAINER] org.apache.catalina.startup.Catalina               INFO    Server startup in 9775 ms"
-    ) do
 
-      # log tag only (no fail tags)
-      it { expect(subject["tags"]).to eq ["log"] }
+  describe "#if" do
 
-      it "should set fields from 'grok'" do
-        expect(subject["@message"]).to eq "Server startup in 9775 ms"
-        expect(subject["@level"]).to eq "INFO"
-        expect(subject["log"]["logger"]).to eq "[CONTAINER] org.apache.catalina.startup.Catalina"
-      end
-
-    end
-  end
-
-  describe "when message is Logback status log" do
-    when_parsing_log(
-        "@type" => "LogMessage", # good type
-        "@source" => { "component" => "App" }, # good component
-        "@level" => "SOME LEVEL",
-        # Logback status log
-        "@message" => "16:41:17,033 |-DEBUG in ch.qos.logback.classic.joran.action.RootLoggerAction - Setting level of ROOT logger to WARN"
-    ) do
-
-      # log tag only (no fail tags)
-      it { expect(subject["tags"]).to eq ["log"] }
-
-      it "should set fields from 'grok'" do
-        expect(subject["@message"]).to eq "Setting level of ROOT logger to WARN"
-        expect(subject["@level"]).to eq "DEBUG"
-        expect(subject["log"]["logger"]).to eq "ch.qos.logback.classic.joran.action.RootLoggerAction"
-      end
-
-    end
-  end
-
-  describe "when message is unknown format" do
-
-    when_parsing_log(
-        "@type" => "LogMessage", # good type
-        "@source" => { "component" => "App" }, # good component
-        "@level" => "SOME LEVEL",
-        "@message" => "Some Message" # unknown format
-    ) do
-
-      # log tag, unknown_msg_format tag
-      it { expect(subject["tags"]).to eq ["log", "unknown_msg_format"] }
-
-      it "should keep fields" do
-        expect(subject["@message"]).to eq "Some Message"
-        expect(subject["@level"]).to eq "SOME LEVEL"
-      end
-
-    end
-  end
-
-
-  describe "when NOT app log case" do
-
-    context "(bad @type)" do
+    context "failed (bad @type)" do
       when_parsing_log(
           "@type" => "Some type", # bad value
-          "@source" => {"component" => "App"},
+          "@source" => {"component" => "APP"},
           "@level" => "INFO",
           "@message" => "Some message of wrong format"
       ) do
@@ -177,10 +181,10 @@ Some exception"
       end
     end
 
-    context "(bad [@source][component])" do
+    context "failed (bad [@source][component])" do
       when_parsing_log(
           "@type" => "LogMessage",
-          "@source" => {"component" => "Bad value"}, # bad value
+          "@source" => {"component" => "Some value"}, # bad value
           "@level" => "INFO",
           "@message" => "Some message of wrong format"
       ) do
@@ -191,6 +195,19 @@ Some exception"
       end
     end
 
+    context "failed (lowercase [@source][component])" do
+      when_parsing_log(
+          "@type" => "LogMessage",
+          "@source" => {"component" => "App"}, # lowercase - bad value
+          "@level" => "INFO",
+          "@message" => "Some message of wrong format"
+      ) do
+
+        # no log tags => 'if' condition has failed
+        it { expect(subject["tags"]).to be_nil }
+
+      end
+    end
   end
 
 end


### PR DESCRIPTION
The thing is that Dea CF used to pass 'App' source_type in app logs (while passing other sources uppercase e.g. 'RTR', 'STG' etc.).
New Diego CF passes all sources as uppercase. So we uppercase [@source][component] after parsing source_type to make it conventional.

Update unit tests accordingly. Also add integration tests (testing LogMessage APP events) for both cases - Diego CF and Dea CF.
Do useful refactoring in app-it-spec.rb to make adding new tests to it easier.