### PR TITLE
fix elasticsearch_index_type property

### DIFF
--- a/templates/stub.logsearch-for-cloudfoundry.yml
+++ b/templates/stub.logsearch-for-cloudfoundry.yml
@@ -54,7 +54,7 @@ properties:
   logstash_parser:
     debug: false
     elasticsearch_index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
-    elasticsearch_index_type: "%{[@metadata][type]}"
+    elasticsearch_index_type: "%{@type}"
   syslog:
     host: (( grab jobs.ingestor.networks.[0].static_ips.[0] ))
     port: 5514


### PR DESCRIPTION
Hi!
I updated stub, the current value for `elasticsearch_index_type` property outdated and should be changed to `"%{@type}"`.  
/cc @hannayurkevich 