### PR TITLE
Add missing elastic properties to UAA template.

### DIFF
--- a/templates/logsearch-for-cf.example-with-uaa-auth.yml
+++ b/templates/logsearch-for-cf.example-with-uaa-auth.yml
@@ -26,6 +26,9 @@ jobs:
   - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
   properties:
     logstash_parser:
+      debug: false
+      elasticsearch_index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
+      elasticsearch_index_type: "%{@type}"
       filters:
       - logsearch-for-cf: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
 
@@ -61,7 +64,3 @@ jobs:
       - REDIS_HOST: my_redis_host # Redis host to use for sessions
       plugins:
       - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.tar.gz
-
-
-
-


### PR DESCRIPTION
Brings UAA template in line with `stub.logsearch-for-cloudfoundry.yml`.

h/t @linuxBozo