### PR TITLE
Firehose parsing: parse new fields

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -69,6 +69,10 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
           rename => { "[app][origin]"        => "[@source][origin]" } # CF logging component
           rename => { "[app][message_type]"  => "[@source][message_type]" } # OUT/ ERR
+
+          rename => { "[app][deployment]" => "[@source][deployment]" }
+          rename => { "[app][ip]" => "[@source][host]" }
+          rename => { "[app][job]" => "[@source][job]" }
         }
 
         # ------------- common fields ------------------

--- a/src/logsearch-config/src/logstash-filters/snippets/platform.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform.conf
@@ -11,13 +11,6 @@ if [@type] in ["syslog", "relp"] and [syslog_program] != "doppler" {
 
     if !("fail/cloudfoundry/platform/grok" in [tags]) {
 
-        # ------------- common fields ------------------
-
-        # override @source.name
-        mutate {
-          add_field => { "[@source][name]" => "%{[@source][job]}/%{[@source][instance]}" }
-        }
-
         # override index, @type & tags
         mutate {
           replace => { "[@metadata][index]" => "platform" }

--- a/src/logsearch-config/src/logstash-filters/snippets/setup.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/setup.conf
@@ -30,5 +30,4 @@ mutate {
 # @source (component, host)
 mutate {
   add_field => { "[@source][component]" => "%{syslog_program}" } # @source.component
-  rename => { "[host]" => "[@source][host]" }
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -24,14 +24,20 @@ if ![@level] and [syslog_severity_code] { # @level
 
 # -- Apply common logic to some fields
 
-if ![@source][name] and ([@source][component] and [@source][instance]) {
+if ![@source][name] and ([@source][job] and [@source][instance]) {
   mutate {
-    add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
+    add_field => { "[@source][name]" => "%{[@source][job]}/%{[@source][instance]}" }
   }
 }
 
 mutate {
   convert => { "[@source][instance]" => "integer" }
+}
+
+if ![@source][host] {
+  mutate {
+   rename => { "[host]" => "[@source][host]" }
+  }
 }
 
 # -- Cleanup unnecessary fields
@@ -55,4 +61,5 @@ mutate {
   rename => { "[tags]" => "[@tags]" }
   uppercase => [ "@level" ]
   remove_field => [ "@version" ]
+  remove_field => "host"
 }

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -44,7 +44,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "INFO", "Some text msg")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "INFO", "Some text msg")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to include "unknown_msg_format" }
@@ -63,7 +64,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "ERROR", "Some json msg")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "ERROR", "Some json msg")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to include "log" }
@@ -83,8 +85,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
-                        "DEBUG", "Server startup in 9775 ms")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "DEBUG", "Server startup in 9775 ms")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
@@ -100,8 +102,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
-                        "DEBUG", "Setting level of ROOT logger to WARN")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "DEBUG", "Setting level of ROOT logger to WARN")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
@@ -129,7 +131,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "INFO", "Some text msg")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "INFO", "Some text msg")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to include "unknown_msg_format" }
@@ -148,7 +151,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP", "ERROR", "Some json msg")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "ERROR", "Some json msg")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to include "log" }
@@ -168,8 +172,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
-                        "DEBUG", "Server startup in 9775 ms")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "DEBUG", "Server startup in 9775 ms")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to_not include "unknown_msg_format" }
@@ -185,8 +189,8 @@ describe "App Integration Test" do
         sample_event["@message"] = construct_app_message(app_message_payload)
 
         when_parsing_log(sample_event) do
-          verify_fields(app_message_payload.origin, app_message_payload.event_type, "APP",
-                        "DEBUG", "Setting level of ROOT logger to WARN")
+          verify_fields(app_message_payload.origin, app_message_payload.job,
+                        app_message_payload.event_type, "APP", "DEBUG", "Setting level of ROOT logger to WARN")
 
           # verify format-specific fields
           it { expect(subject["@tags"]).to_not include "unknown_msg_format" }

--- a/src/logsearch-config/test/logstash-filters/it_app_helper.rb
+++ b/src/logsearch-config/test/logstash-filters/it_app_helper.rb
@@ -63,7 +63,7 @@ def construct_app_message (message_payload)
     "time":"2016-07-08T10:00:40Z", "timestamp":1467972040073786262 }'
 end
 
-def verify_fields (expected_origin, expected_type, expected_source, expected_level, expected_message)
+def verify_fields (expected_origin, expected_job, expected_type, expected_source, expected_level, expected_message)
 
   # no parsing errors
   it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/app/json" }
@@ -73,9 +73,11 @@ def verify_fields (expected_origin, expected_type, expected_source, expected_lev
     expect(subject["@input"]).to eq "syslog"
     expect(subject["@shipper"]["priority"]).to eq "6"
     expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
-    expect(subject["@source"]["host"]).to eq "bed08922-4734-4d62-9eba-3291aed1b8ce"
-    expect(subject["@source"]["name"]).to eq (expected_source + "/0")
+    expect(subject["@source"]["host"]).to eq "192.168.111.35"
+    expect(subject["@source"]["name"]).to eq (expected_job + "/0")
     expect(subject["@source"]["instance"]).to eq 0
+    expect(subject["@source"]["deployment"]).to eq "cf-full"
+    expect(subject["@source"]["job"]).to eq expected_job
 
     expect(subject["@metadata"]["index"]).to eq "app-admin-demo"
   end

--- a/src/logsearch-config/test/logstash-filters/snippets/platform-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/platform-spec.rb
@@ -26,7 +26,6 @@ describe "platform.conf" do
         # fields
         it "should set grok fields" do
           expect(subject["@message"]).to eq "Some message"
-          expect(subject["@source"]["name"]).to eq "nfs_z1/0"
           expect(subject["@source"]["job"]).to eq "nfs_z1"
           expect(subject["@source"]["instance"]).to eq "0"
         end

--- a/src/logsearch-config/test/logstash-filters/snippets/setup-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/setup-spec.rb
@@ -50,7 +50,6 @@ describe "setup.conf" do
           "@type" => "some-type",
           "syslog_program" => "some-program",
           "syslog_pri" => "5",
-          "host" => "1.2.3.4",
           "@message" => "Some message" # OK
       ) do
 
@@ -63,8 +62,6 @@ describe "setup.conf" do
         it { expect(subject["@shipper"]["priority"]).to eq "5" }
         it { expect(subject["@shipper"]["name"]).to eq "some-program_some-type" }
         it { expect(subject["@source"]["component"]).to eq "some-program" }
-        it { expect(subject["@source"]["host"]).to eq "1.2.3.4" }
-        it { expect(subject["host"]).to be_nil }
 
       end
     end

--- a/src/logsearch-config/test/logstash-filters/snippets/teardown-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/teardown-spec.rb
@@ -67,13 +67,13 @@ describe "teardown.conf" do
 
     context "when [@source]* fields are set" do
       when_parsing_log(
-          "@source" => {"component" => "Abc", "instance" => "123"}
+          "@source" => {"job" => "Abc", "instance" => "123"}
       ) do
         it { expect(subject["@source"]["name"]).to eq "Abc/123" }
       end
     end
 
-    context "when [@source][component] is missing" do
+    context "when [@source][job] is missing" do
       when_parsing_log(
           "@source" => {"instance" => "123"}
       ) do
@@ -83,7 +83,7 @@ describe "teardown.conf" do
 
     context "when [@source][instance] is missing" do
       when_parsing_log(
-          "@source" => {"component" => "Abc"}
+          "@source" => {"job" => "Abc"}
       ) do
         it { expect(subject["@source"]["name"]).to be_nil }
       end
@@ -109,6 +109,40 @@ describe "teardown.conf" do
 
   end
 
+  describe "converts [@source][instance]" do
+
+    when_parsing_log(
+        "@source" => {"instance" => "123"}
+    ) do
+      it { expect(subject["@source"]["instance"]).to eq 123 }
+    end
+
+  end
+
+  describe "parse [host]" do
+
+    context "when [@source][host] is set" do
+      when_parsing_log(
+          "host" => "1.2.3.4",
+          "@source" => {"host" => "5.6.7.8"}
+      ) do
+        it { expect(subject["@source"]["host"]).to eq "5.6.7.8" }
+        it { expect(subject["host"]).to be_nil }
+      end
+    end
+
+    context "when [@source][host] is NOT set" do
+      when_parsing_log(
+          "host" => "1.2.3.4"
+      ) do
+        it { expect(subject["@source"]["host"]).to eq "1.2.3.4" }
+        it { expect(subject["host"]).to be_nil }
+      end
+    end
+
+  end
+
+
   describe "cleanup" do
 
     when_parsing_log(
@@ -124,7 +158,8 @@ describe "teardown.conf" do
       "syslog_pid" => "z",
       "tags" => ["t1", "t2"],
       "@level" => "lowercase value",
-      "@version" => "some version"
+      "@version" => "some version",
+      "host" => "1.2.3.4"
     ) do
 
       it "should remove syslog fields" do
@@ -148,6 +183,8 @@ describe "teardown.conf" do
       it { expect(subject["@level"]).to eq "LOWERCASE VALUE" }
 
       it { expect(subject["@version"]).to be_nil }
+
+      it { expect(subject["host"]).to be_nil }
 
     end
 


### PR DESCRIPTION
Recent version of firehose-to-syslog passes new fields in json message: deployment, ip, job. Add parsing rules for these fields. Update tests accordingly.