### PR TITLE
Add errand to upload kibana dashboards.

### DIFF
--- a/jobs/upload-kibana-dashboards/spec
+++ b/jobs/upload-kibana-dashboards/spec
@@ -1,0 +1,12 @@
+---
+name: upload-kibana-dashboards
+packages:
+- logsearch-for-cloudfoundry-filters
+templates:
+  bin/run: bin/run
+
+properties:
+  elasticsearch.host:
+    description: Elasticsearch host
+  elasticsearch.port:
+    description: Elasticsearch port

--- a/jobs/upload-kibana-dashboards/templates/bin/run
+++ b/jobs/upload-kibana-dashboards/templates/bin/run
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+
+# Upload Kibana dashboards
+cat /var/vcap/packages/logsearch-for-cloudfoundry-filters/kibana4-dashboards.json | curl --data-binary @- http://<%= p('elasticsearch.host') %>:<%= p('elasticsearch.port') %>/_bulk

--- a/src/logsearch-config/Rakefile
+++ b/src/logsearch-config/Rakefile
@@ -33,7 +33,7 @@ end
 
 desc "Runs JSON validation tests"
 task :json, [:json_files] => :build do |t, args|
-  args.with_defaults(:json_files => "$(find target -name *.json)")
+  args.with_defaults(:json_files => "$(find target -name *.json ! -name kibana4-dashboards.json)")
   puts "===> Validating JSON data ..."
   sh %Q[ jsonlint #{args[:json_files]} ]
 end

--- a/src/logsearch-config/Rakefile
+++ b/src/logsearch-config/Rakefile
@@ -11,6 +11,7 @@ task :build => :clean do
   puts "===> Building ..."
   compile_erb 'src/logstash-filters/default.conf.erb', 'target/logstash-filters-default.conf'
   compile_erb 'src/es-mappings/logs-template.json.erb', 'target/logs-template.json'
+  compile_erb 'src/kibana4-dashboards/kibana4-dashboards.json.erb', 'target/kibana4-dashboards.json'
 
   puts "===> Artifacts:"
   puts `find target`

--- a/templates/logsearch-for-cf.example-with-uaa-auth.yml
+++ b/templates/logsearch-for-cf.example-with-uaa-auth.yml
@@ -49,6 +49,20 @@ jobs:
         system_domain: sys.cf.example
         admin_client_secret: admin_client_secret
 
+- name: upload-kibana-dashboards
+  lifecycle: errand
+  release: logsearch-for-cloudfoundry
+  instances: 1
+  templates:
+  - {name: upload-kibana-dashboards, release: logsearch-for-cloudfoundry}
+  networks:
+  - name: default
+  resource_pool: errand
+  properties:
+    elasticsearch:
+      host: elastic_host
+      port: 9200
+
 - name: kibana
   templates:
   - (( merge ))

--- a/templates/logsearch-for-cf.example-with-uaa-auth.yml
+++ b/templates/logsearch-for-cf.example-with-uaa-auth.yml
@@ -60,7 +60,7 @@ jobs:
   resource_pool: errand
   properties:
     elasticsearch:
-      host: elastic_host
+      host: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
       port: 9200
 
 - name: kibana

--- a/templates/stub.logsearch-for-cloudfoundry.yml
+++ b/templates/stub.logsearch-for-cloudfoundry.yml
@@ -47,7 +47,7 @@ jobs:
   resource_pool: errand
   properties:
     elasticsearch:
-      host: elastic_host
+      host: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
       port: 9200
 
 properties:

--- a/templates/stub.logsearch-for-cloudfoundry.yml
+++ b/templates/stub.logsearch-for-cloudfoundry.yml
@@ -36,6 +36,20 @@ jobs:
   networks:
   - name: default
 
+- name: upload-kibana-dashboards
+  lifecycle: errand
+  release: logsearch-for-cloudfoundry
+  instances: 1
+  templates:
+  - {name: upload-kibana-dashboards, release: logsearch-for-cloudfoundry}
+  networks:
+  - name: default
+  resource_pool: errand
+  properties:
+    elasticsearch:
+      host: elastic_host
+      port: 9200
+
 properties:
   cloudfoundry:
     api_endpoint: https://api.example.com


### PR DESCRIPTION
This patch adds an errand to upload kibana dashboards to elastic, since it looks like that step was dropped at some point (although it's still described in https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/master/src/logsearch-config/src/kibana4-dashboards/README.md).

Written with @LinuxBozo 