### PR TITLE
Add missing elastic mapping to UAA template.

### DIFF
--- a/templates/logsearch-for-cf.example-with-uaa-auth.yml
+++ b/templates/logsearch-for-cf.example-with-uaa-auth.yml
@@ -32,6 +32,15 @@ jobs:
       filters:
       - logsearch-for-cf: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logstash-filters-default.conf
 
+- name: maintenance
+  templates:
+  - (( merge ))
+  - {name: logsearch-for-cloudfoundry-filters, release: logsearch-for-cloudfoundry}
+  properties:
+    elasticsearch_config:
+      templates:
+      - index_template: /var/vcap/packages/logsearch-for-cloudfoundry-filters/logs-template.json
+
 - name: create-uaa-client
   lifecycle: errand
   release: logsearch-for-cloudfoundry


### PR DESCRIPTION
Without adding `logsearch-for-cloudfoundry-filters` to a job also using `elasticsearch_config` and setting the `templates` property, the expected elastic mapping template wouldn't be used, which could be hard to debug. Hypothetically 😉 .

cc @LinuxBozo 