### PR TITLE
Exclude src from YAML validation

### DIFF
--- a/src/logsearch-config/Rakefile
+++ b/src/logsearch-config/Rakefile
@@ -39,7 +39,7 @@ end
 
 desc "Runs YAML validation tests"
 task :yaml, [:yaml_files] => :build do |t, args|
-  args.with_defaults(:yaml_files => "$(find ../.. -path ../../src/logsearch-config/vendor -prune -o -name '*.yml' -print)")
+  args.with_defaults(:yaml_files => "$(find ../.. -path ../../src -prune -o -name '*.yml' -print)")
   puts "===> Validating YAML data ..."
   sh %Q[ yaml-lint #{args[:yaml_files]} ]
 end


### PR DESCRIPTION
Hi @axelaris 
I have excluded `src` folder from path for YAML validation tests. `src` folder contains many `.travis.yaml` from submodules which we can skip.