### PR TITLE
Store parsed json to a field with name of @source.component

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -1,6 +1,6 @@
 # -- Apply default settings for mandatory fields (if not set)
 
-# Set syslog @level (if @level is not set yet)
+# set syslog @level (if @level is not set yet)
 if ![@level] and [syslog_severity_code] { # @level
 
     if [syslog_severity_code] <= 3 { # 0-Emergency, 1-Alert, 2-Critical, 3-Error
@@ -22,21 +22,31 @@ if ![@level] and [syslog_severity_code] { # @level
     }
 }
 
-# -- Apply common logic to some fields
+# -- Rework fields
 
+# @source fields
 if ![@source][name] and ([@source][job] and [@source][instance]) {
-  mutate {
-    add_field => { "[@source][name]" => "%{[@source][job]}/%{[@source][instance]}" }
-  }
+  mutate { add_field => { "[@source][name]" => "%{[@source][job]}/%{[@source][instance]}" } }
 }
 
-mutate {
-  convert => { "[@source][instance]" => "integer" }
-}
+mutate { convert => { "[@source][instance]" => "integer" } }
 
 if ![@source][host] {
+  mutate { rename => { "[host]" => "[@source][host]" } }
+}
+
+# dynamic [parsed_json_data] field
+# store [parsed_json_data] to calculated field name (get @source.component downcase it and replace special characters with '_')
+if [parsed_json_data] and [@source][component] {
   mutate {
-   rename => { "[host]" => "[@source][host]" }
+    add_field => { "json_field_name" => "%{[@source][component]}"}
+  }
+  mutate {
+    gsub => [ "json_field_name", "[\s/\\?#-\.]", "_" ]
+  }
+  ruby {
+    code => "event[event['json_field_name'].to_s.downcase] = LogStash::Util.normalize(event['parsed_json_data'])"
+    remove_field => [ "json_field_name", "parsed_json_data" ]
   }
 }
 

--- a/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/vcap.conf
@@ -1,28 +1,8 @@
 if [@type] == "cf" and ([syslog_program] != "vcap.uaa" and [syslog_program] =~ /vcap\..*/) {
 
-    # Parse Cloud Foundry logs from syslog_aggregator
+    # Parse Cloud Foundry logs
 
-    # -------- message additional parsing & specific fields ----------
-    # JSON parsing
-    if [@message] =~ /^\s*{".*}\s*$/ {
-
-        json {
-          source => "@message"
-          target => "vcap"
-          remove_field => [ "@message" ]
-        }
-
-        mutate {
-          convert => { "[vcap][log_level]" => "string" }
-        }
-        mutate {
-          rename => { "[vcap][log_level]" => "@level" } # @level
-          rename => { "[vcap][message]" => "@message" } # @message
-        }
-
-    }
-
-    # -------- override @source.component, type, tags ----------
+    # -------- vcap: general fields ----------
     ruby {
       code => "event['[@source][component]'] = event['[@source][component]'][5..-1]" # minus "vcap." prefix
     }
@@ -30,6 +10,23 @@ if [@type] == "cf" and ([syslog_program] != "vcap.uaa" and [syslog_program] =~ /
       replace => { "@type" => "vcap_cf" }
       add_tag => "vcap"
     }
-    # ----------------------------------------------------------
 
+    # -------- vcap: message additional parsing ----------
+
+    if [@message] =~ /^\s*{".*}\s*$/ { # looks like JSON
+
+        # parse JSON message
+        json {
+          source => "@message"
+          target => "parsed_json_data"
+          remove_field => [ "@message" ]
+        }
+
+        mutate { convert => { "[parsed_json_data][log_level]" => "string" } }
+        mutate {
+          rename => { "[parsed_json_data][log_level]" => "@level" } # @level
+          rename => { "[parsed_json_data][message]" => "@message" } # @message
+        }
+
+    }
 }

--- a/src/logsearch-config/test/filter_test_helpers.rb
+++ b/src/logsearch-config/test/filter_test_helpers.rb
@@ -36,13 +36,13 @@ def when_parsing_log(sample_event, &block)
       name = LogStash::Json.dump(sample_event)
     end
 
+    event = LogStash::Event.new(sample_event)
+
     name = name[0..200] + "..." if name.length > 200
 
     describe "[\"#{name}\"]" do
 
       before(:all) do
-        event = LogStash::Event.new(sample_event)
-
         results = []
         # filter call the block on all filtered events, included new events added by the filter
         LogStashPipeline.instance.filter(event) { |filtered_event| results << filtered_event }
@@ -56,4 +56,6 @@ def when_parsing_log(sample_event, &block)
 
       describe("", &block)
     end
+
+    event
 end

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
 require 'test/filter_test_helpers'
-require 'test/logstash-filters/it_app_helper'
+require 'test/logstash-filters/it_app_helper' # app it util
 
-describe "App Integration Test" do
+describe "App logs IT" do
 
   before(:all) do
     load_filters <<-CONFIG

--- a/src/logsearch-config/test/logstash-filters/it/unparsed-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/unparsed-it-spec.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+require 'test/filter_test_helpers'
+
+describe "Undefined logs IT" do
+
+  before(:all) do
+    load_filters <<-CONFIG
+      filter {
+        #{File.read("target/logstash-filters-default.conf")} # NOTE: we use already built config here
+      }
+    CONFIG
+  end
+
+  describe "undefined log" do
+
+    when_parsing_log(
+        "@type" => "relp",
+        "syslog_program" => "some-program", # not a platform log
+        "syslog_pri" => "14",
+        "syslog_severity_code" => 3,
+        "host" => "192.168.111.24:44577",
+        "@message" => "Some message" # not a platform log
+    ) do
+
+      # parsing error
+      it { expect(subject["@tags"]).to include "fail/cloudfoundry/platform/grok" }
+
+      # fields
+      it "should set common fields" do
+        expect(subject["@input"]).to eq "relp"
+        expect(subject["@shipper"]["priority"]).to eq "14"
+        expect(subject["@shipper"]["name"]).to eq "some-program_relp"
+        expect(subject["@source"]["host"]).to eq "192.168.111.24:44577"
+        expect(subject["@source"]["name"]).to be_nil
+        expect(subject["@source"]["instance"]).to be_nil
+        expect(subject["@source"]["component"]).to eq "some-program"
+        expect(subject["@type"]).to eq "relp"
+
+        expect(subject["@metadata"]["index"]).to eq "unparsed"
+      end
+
+      it "should set mandatory fields" do
+        expect(subject["@message"]).to eq "Some message"
+        expect(subject["@level"]).to eq "ERROR"
+      end
+
+    end
+
+  end
+
+end

--- a/src/logsearch-config/test/logstash-filters/it_app_helper.rb
+++ b/src/logsearch-config/test/logstash-filters/it_app_helper.rb
@@ -58,7 +58,7 @@ def construct_app_message (message_payload)
     "message_type":"OUT",
     "msg":"' + message_payload.msg + '" ,
     "origin":"' + message_payload.origin + '" ,
-    "source_instance":"0",
+    "source_instance":"5",
     "source_type":"' + message_payload.source_type + '",
     "time":"2016-07-08T10:00:40Z", "timestamp":1467972040073786262 }'
 end
@@ -74,8 +74,8 @@ def verify_fields (expected_origin, expected_job, expected_type, expected_source
     expect(subject["@shipper"]["priority"]).to eq "6"
     expect(subject["@shipper"]["name"]).to eq "doppler_syslog"
     expect(subject["@source"]["host"]).to eq "192.168.111.35"
-    expect(subject["@source"]["name"]).to eq (expected_job + "/0")
-    expect(subject["@source"]["instance"]).to eq 0
+    expect(subject["@source"]["name"]).to eq (expected_job + "/5")
+    expect(subject["@source"]["instance"]).to eq 5
     expect(subject["@source"]["deployment"]).to eq "cf-full"
     expect(subject["@source"]["job"]).to eq expected_job
 

--- a/src/logsearch-config/test/logstash-filters/it_platform_helper.rb
+++ b/src/logsearch-config/test/logstash-filters/it_platform_helper.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+class MessagePayload
+  attr_accessor :job, :message_text
+end
+
+class MessagePayloadBuilder
+  attr_accessor :message_payload
+
+  def initialize
+    @message_payload = MessagePayload.new
+  end
+
+  def build
+    @message_payload
+  end
+
+  def job(job)
+    @message_payload.job = job
+    self
+  end
+
+  def message_text(message_text)
+    @message_payload.message_text = message_text
+    self
+  end
+
+end
+
+def construct_platform_message (message_payload)
+  '[job='+ message_payload.job + ' index=5]  ' + message_payload.message_text
+end
+
+def verify_fields (expected_shipper, expected_component, expected_job, expected_type, expected_tags, expected_message, expected_level)
+
+  # no parsing errors
+  it { expect(subject["@tags"]).not_to include "fail/cloudfoundry/platform/grok" }
+
+  # fields
+  it { expect(subject["@message"]).to eq expected_message }
+  it { expect(subject["@level"]).to eq expected_level }
+
+  it { expect(subject["@input"]).to eq "relp" }
+  it { expect(subject["@shipper"]["priority"]).to eq "14" }
+  it { expect(subject["@shipper"]["name"]).to eq expected_shipper } #"vcap.consul-agent_relp"
+  it { expect(subject["@source"]["host"]).to eq "192.168.111.24" }
+  it { expect(subject["@source"]["name"]).to eq expected_job + "/5" }
+  it { expect(subject["@source"]["instance"]).to eq 5 }
+  it { expect(subject["@source"]["component"]).to eq expected_component }
+  it { expect(subject["@metadata"]["index"]).to eq "platform" }
+  it { expect(subject["@type"]).to eq expected_type }
+  it { expect(subject["@tags"]).to eq expected_tags }
+
+end

--- a/src/logsearch-config/test/logstash-filters/snippets/teardown-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/teardown-spec.rb
@@ -142,6 +142,35 @@ describe "teardown.conf" do
 
   end
 
+  describe "renames [parsed_json_data]" do
+
+    describe "when [parsed_json_data] and [@source][component] are set" do
+      when_parsing_log(
+          "parsed_json_data" => "dummy value",
+          "@source" => {"component" => "Abc-defg.hI?jk#lm NOPQ"}
+      ) do
+        it { expect(subject["parsed_json_data"]).to be_nil }
+        it { expect(subject["abc_defg_hi_jk_lm_nopq"]).to eq "dummy value" } # renamed
+      end
+    end
+
+    context "when [parsed_json_data] is NOT set" do
+      event = when_parsing_log(
+          "some useless field" => "some value"
+      ) do
+        it { expect(subject).to eq event } # no changes
+      end
+    end
+
+    context "when [@source][component] is NOT set" do
+      event = when_parsing_log(
+          "parsed_json_data" => "dummy value"
+      ) do
+        it { expect(subject).to eq event } # no changes
+      end
+    end
+
+  end
 
   describe "cleanup" do
 
@@ -162,20 +191,20 @@ describe "teardown.conf" do
       "host" => "1.2.3.4"
     ) do
 
-      it "should remove syslog fields" do
+      it "removes syslog_ fields" do
         expect(subject["syslog_pri"]).to be_nil
         expect(subject["syslog_facility"]).to be_nil
         expect(subject["syslog_facility_code"]).to be_nil
         expect(subject["syslog_message"]).to be_nil
         expect(subject["syslog_severity"]).to be_nil
-        expect(subject[ "syslog_severity_code"]).to be_nil
+        expect(subject["syslog_severity_code"]).to be_nil
         expect(subject["syslog_program"]).to be_nil
         expect(subject["syslog_timestamp"]).to be_nil
         expect(subject["syslog_hostname"]).to be_nil
         expect(subject["syslog_pid"]).to be_nil
       end
 
-      it "should rename tags field" do
+      it "renames 'tags' field" do
         expect(subject["@tags"]).to eq ["t1", "t2"]
         expect(subject["tags"]).to be_nil
       end
@@ -185,7 +214,7 @@ describe "teardown.conf" do
       it { expect(subject["@version"]).to be_nil }
 
       it { expect(subject["host"]).to be_nil }
-
+      
     end
 
   end


### PR DESCRIPTION
Different vcap components have different JSON messages, but they could contain JSON properties with the same name and different datatype. Elasticsearch doesn't allow fields with the same name to have different datatypes. In case of conflicts Logstash reports warning and conflicted values can be lost.

So to avoid such conflicts we now store parsed JSON to different target fields for different components. Name of target field is `@source.component` downcased and with '_' delimiter (naming is the same as in [logsearch-boshrelease json parsing](https://github.com/logsearch/logsearch-boshrelease/blob/develop/src/logsearch-config/src/logstash-filters/if_it_looks_like_json.conf#L71)).