### PR TITLE
Add templated options to kibana config.

### DIFF
--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -48,6 +48,18 @@ properties:
   cf-kibana.session_expiration_ms:
     description: "Kibana user session expiration period in milliseconds (default to 12h)"
     default: 43200000
+  cf-kibana.default_app_id:
+    description: "The default application to load"
+    default: "dashboard/App-Overview"
+  cf-kibana.kibana_index:
+    description: "Kibana uses an index in Elasticsearch to store saved searches, visualizations and dashboards"
+    default: ".kibana"
+  cf-kibana.request_timeout:
+    description: "Time in milliseconds to wait for responses from the back end or elasticsearch.  This must be > 0"
+    default: 300000
+  cf-kibana.shard_timeout:
+    description: "Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable"
+    default: 30000
 
   cloudfoundry.api_endpoint:
     description: "The CF API URL"

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -21,10 +21,12 @@ elasticsearch.preserveHost: true
 
 # Kibana uses an index in Elasticsearch to store saved searches, visualizations and
 # dashboards. Kibana creates a new index if the index doesn’t already exist.
-kibana.index: ".kibana"
+# kibana.index: ".kibana"
+kibana.index: "<%= p('cf-kibana.kibana_index') %>"
 
 # The default application to load.
 # kibana.defaultAppId: "discover"
+kibana.defaultAppId: "<%= p('cf-kibana.default_app_id') %>"
 
 # If your Elasticsearch is protected with basic authentication, these settings provide
 # the username and password that the Kibana server uses to perform maintenance on the Kibana
@@ -57,9 +59,11 @@ kibana.index: ".kibana"
 # Time in milliseconds to wait for responses from the back end or Elasticsearch. This value
 # must be a positive integer.
 # elasticsearch.requestTimeout: 300000
+elasticsearch.requestTimeout: <%= p('cf-kibana.request_timeout') %>
 
 # Time in milliseconds for Elasticsearch to wait for responses from shards. Set to 0 to disable.
 # elasticsearch.shardTimeout: 0
+elasticsearch.shardTimeout: <%= p('cf-kibana.shard_timeout') %>
 
 # Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying.
 # elasticsearch.startupTimeout: 5000


### PR DESCRIPTION
Taken verbatim from
https://github.com/logsearch/logsearch-boshrelease/tree/v203.0.0/jobs/kibana.

While debugging a separate issue, I noticed that the kibana config is missing some potentially useful options, like choosing the default app--the default is "discover", which doesn't exist here. I just copied options that were available in logsearch-boshrelease and added them here.