### PR TITLE
Update RTR field names to match logstash templates.

### DIFF
--- a/src/logsearch-config/src/kibana4-dashboards/search/app-RTR-response_time_ms-lt-2000.json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/search/app-RTR-response_time_ms-lt-2000.json.erb
@@ -5,10 +5,10 @@
   "hits": 0,
   "columns": [
     "@source.app",
-    "RTR.verb",
-    "RTR.response_time_ms",
-    "RTR.status",
-    "RTR.path"
+    "rtr.verb",
+    "rtr.response_time_ms",
+    "rtr.status",
+    "rtr.path"
   ],
   "sort": [
     "@timestamp",
@@ -22,7 +22,7 @@
       "query": {
         "query_string": {
           "analyze_wildcard": true,
-          "query": "RTR.response_time_ms:<2000"
+          "query": "rtr.response_time_ms:<2000"
         }
       },
       "highlight": {

--- a/src/logsearch-config/src/kibana4-dashboards/search/app-RTR.json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/search/app-RTR.json.erb
@@ -5,10 +5,10 @@
   "hits": 0,
   "columns": [
     "@source.app",
-    "RTR.verb",
-    "RTR.response_time_ms",
-    "RTR.status",
-    "RTR.path"
+    "rtr.verb",
+    "rtr.response_time_ms",
+    "rtr.status",
+    "rtr.path"
   ],
   "sort": [
     "@timestamp",

--- a/src/logsearch-config/src/kibana4-dashboards/visualization/App-names-and-response-times.json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/visualization/App-names-and-response-times.json.erb
@@ -26,7 +26,7 @@
           "type": "percentiles",
           "schema": "metric",
           "params": {
-            "field": "RTR.response_time_ms",
+            "field": "rtr.response_time_ms",
             "percents": [
               50,
               95

--- a/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-response-time-distribution-(-top-10-apps-).json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-response-time-distribution-(-top-10-apps-).json.erb
@@ -44,7 +44,7 @@
           "type": "histogram",
           "schema": "segment",
           "params": {
-            "field": "RTR.response_time_ms",
+            "field": "rtr.response_time_ms",
             "interval": 50,
             "extended_bounds": {
             }

--- a/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-response-times-(top-10-apps).json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-response-times-(top-10-apps).json.erb
@@ -29,7 +29,7 @@
           "type": "percentiles",
           "schema": "metric",
           "params": {
-            "field": "RTR.response_time_ms",
+            "field": "rtr.response_time_ms",
             "percents": [
               50,
               95

--- a/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-traffic-by-response_time_ms-(first-10-apps).json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-traffic-by-response_time_ms-(first-10-apps).json.erb
@@ -57,7 +57,7 @@
           "type": "histogram",
           "schema": "group",
           "params": {
-            "field": "RTR.response_time_ms",
+            "field": "rtr.response_time_ms",
             "interval": 500,
             "extended_bounds": {
             }

--- a/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-traffic-by-status-code.json.erb
+++ b/src/logsearch-config/src/kibana4-dashboards/visualization/HTTP-traffic-by-status-code.json.erb
@@ -59,7 +59,7 @@
           "type": "terms",
           "schema": "group",
           "params": {
-            "field": "RTR.status",
+            "field": "rtr.status",
             "size": 5,
             "order": "desc",
             "orderBy": "1"


### PR DESCRIPTION
"RTR" is capitalized in the kibana configs but not in the logstash templates. This patch updates the relevant kibana field names.

Part of #159.

cc @LinuxBozo 