### PR TITLE
Pass autoapprove option to UAA client create.

### DIFF
--- a/jobs/create-uaa-client/spec
+++ b/jobs/create-uaa-client/spec
@@ -13,6 +13,9 @@ properties:
     default: kibana_oauth2_client
   create-uaa-client.oauth2_client_secret:
     description: "The UAA kibana oauth2 client id's secret"
+  create-uaa-client.oauth2_autoapprove:
+    description: ""
+    default: false
 
   create-uaa-client.cloudfoundry.system_domain:
     description: "The Elastic Runtime system domain ( eg: system.10.244.0.34.xip.io )"

--- a/jobs/create-uaa-client/templates/bin/run
+++ b/jobs/create-uaa-client/templates/bin/run
@@ -38,6 +38,7 @@ echo "Creating new OAuth2 client: <%= p('create-uaa-client.oauth2_client_id') %>
 -d '{
   "client_id" : "<%= p('create-uaa-client.oauth2_client_id') %>",
   "client_secret" : "<%= p('create-uaa-client.oauth2_client_secret') %>",
+  "autoapprove" : "<%= p('create-uaa-client.oauth2_autoapprove') %>",
   "scope" : ["openid","oauth.approvals","scim.userids","cloud_controller.read"],
   "authorities" : ["uaa.none"],
   "resource_ids" : ["none"],


### PR DESCRIPTION
This application is a good use case for UAA auto-approve, to avoid

>  redundant and annoying requests to grant permission when there is not a reasonable need to ever deny them.

https://github.com/cloudfoundry/uaa/blob/master/docs/Sysadmin-Guide.rst#clients

cc @LinuxBozo