### PR TITLE
App events

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ $ bosh deploy
 ```sh
 $ bosh run errand create-uaa-client
 ```
+
+#### Collecting application events
+
+Note: To collect Cloud Foundry application events, configure and deploy [cf-app-events-logger](https://github.com/18F/cf-app-events-logger) to your Cloud Foundry instance; application events will be printed to standard output and collected via the firehose.

--- a/src/logsearch-config/src/logstash-filters/default.conf.erb
+++ b/src/logsearch-config/src/logstash-filters/default.conf.erb
@@ -12,6 +12,7 @@
 <%= File.read('src/logstash-filters/snippets/app.conf') %>
 # special cases
 <%= File.read('src/logstash-filters/snippets/app-metric.conf') %>
+<%= File.read('src/logstash-filters/snippets/app-event.conf') %>
 <%= File.read('src/logstash-filters/snippets/app-rtr.conf') %>
 <%= File.read('src/logstash-filters/snippets/app-log.conf') %>
 

--- a/src/logsearch-config/src/logstash-filters/snippets/app-event.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-event.conf
@@ -1,0 +1,40 @@
+# Parse messages from /v2/events api logged by https://github.com/18F/cf-app-events-logger
+
+if [@message] =~ /.*"event_type":"AppEvent".*/  {
+
+    json {
+        source => "[@message]"
+        target => "[app_event]"
+        add_tag => "app_event"
+    }
+
+    date {
+        match => [ "[app_event][timestamp]", "ISO8601" ]
+    }
+
+    ruby {
+        code => "event['@metadata']['app_event_metadata_as_string'] = event['app_event']['metadata'].to_s"
+    }
+    mutate {
+        replace => { "[@message]" => "%{[app_event][type]} %{[@metadata][app_event_metadata_as_string]}" }
+    }
+
+    mutate {
+        replace => { "[@source][component]" => "AppEvent" }
+        replace => { "[@source][instance]" => "0" }
+        convert => { "[@source][instance]" => "integer" }
+        replace => { "[@source][name]" => "AppEvent/0" }
+
+        replace => { "[@source][app][id]" => "%{[app_event][app_id]}" }
+        replace => { "[@source][app][name]" => "%{[app_event][app_name]}" }
+        replace => { "[@source][space][id]" => "%{[app_event][space_guid]}" }
+        replace => { "[@source][space][name]" => "%{[app_event][space_name]}" }
+        replace => { "[@source][org][id]" => "%{[app_event][organization_guid]}" }
+        replace => { "[@source][org][name]" => "%{[app_event][organization_name]}" }
+
+        replace => { "[@metadata][type]" => "app_event" }
+
+        remove_field => [ "[@source][message_type]", "[@source][origin]", "[@source][host]" ]
+    }
+
+}

--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -1,43 +1,4 @@
-if [@message] =~ /.*"event_type":"AppEvent".*/ {
-
-    # Parse messages from /v2/events api logged by https://github.com/18F/cf-app-events-logger
-
-    json {
-        source => "[@message]"
-        target => "[app_event]"
-        add_tag => "app_event"
-    }
-
-    date {
-        match => [ "[app_event][timestamp]", "ISO8601" ]
-    }
-
-    ruby {
-        code => "event['@metadata']['app_event_metadata_as_string'] = event['app_event']['metadata'].to_s"
-    }
-    mutate {
-        replace => { "[@message]" => "%{[app_event][type]} %{[@metadata][app_event_metadata_as_string]}" }
-    }
-
-    mutate {
-        replace => { "[@source][component]" => "AppEvent" }
-        replace => { "[@source][instance]" => "0" }
-        convert => { "[@source][instance]" => "integer" }
-        replace => { "[@source][name]" => "AppEvent/0" }
-
-        replace => { "[@source][app][id]" => "%{[app_event][actee]}" }
-        replace => { "[@source][app][name]" => "%{[app_event][events_actee_name]}" }
-        replace => { "[@source][space][id]" => "%{[app_event][space_guid]}" }
-        replace => { "[@source][space][name]" => "%{[app_event][events_space_name]}" }
-        replace => { "[@source][org][id]" => "%{[app_event][organization_guid]}" }
-        replace => { "[@source][org][name]" => "%{[app_event][events_org_name]}" }
-
-        replace => { "[@metadata][type]" => "app_event" }
-
-        remove_field => [ "[@source][message_type]", "[@source][origin]", "[@source][host]" ]
-    }
-
-} else if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
+if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
     # Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)
 
@@ -75,7 +36,7 @@ if [@message] =~ /.*"event_type":"AppEvent".*/ {
           rename => { "[app][msg]" => "@message" } # @message
           rename => { "[app][level]" => "@level" } # @level
         }
-
+        
         # @timestamp
         ruby { # convert [app][timestamp] from nanosec-from-epoch number to Datetime
             init => "require 'time'"
@@ -146,5 +107,4 @@ if [@message] =~ /.*"event_type":"AppEvent".*/ {
           remove_field => "[app]"
         }
     }
-
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -1,4 +1,43 @@
-if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
+if [@message] =~ /.*"event_type":"AppEvent".*/ {
+
+    # Parse messages from /v2/events api logged by https://github.com/18F/cf-app-events-logger
+
+    json {
+        source => "[@message]"
+        target => "[app_event]"
+        add_tag => "app_event"
+    }
+
+    date {
+        match => [ "[app_event][timestamp]", "ISO8601" ]
+    }
+
+    ruby {
+        code => "event['@metadata']['app_event_metadata_as_string'] = event['app_event']['metadata'].to_s"
+    }
+    mutate {
+        replace => { "[@message]" => "%{[app_event][type]} %{[@metadata][app_event_metadata_as_string]}" }
+    }
+
+    mutate {
+        replace => { "[@source][component]" => "AppEvent" }
+        replace => { "[@source][instance]" => "0" }
+        convert => { "[@source][instance]" => "integer" }
+        replace => { "[@source][name]" => "AppEvent/0" }
+
+        replace => { "[@source][app][id]" => "%{[app_event][actee]}" }
+        replace => { "[@source][app][name]" => "%{[app_event][events_actee_name]}" }
+        replace => { "[@source][space][id]" => "%{[app_event][space_guid]}" }
+        replace => { "[@source][space][name]" => "%{[app_event][events_space_name]}" }
+        replace => { "[@source][org][id]" => "%{[app_event][organization_guid]}" }
+        replace => { "[@source][org][name]" => "%{[app_event][events_org_name]}" }
+
+        replace => { "[@metadata][type]" => "app_event" }
+
+        remove_field => [ "[@source][message_type]", "[@source][origin]", "[@source][host]" ]
+    }
+
+} else if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
 
     # Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)
 
@@ -36,7 +75,7 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           rename => { "[app][msg]" => "@message" } # @message
           rename => { "[app][level]" => "@level" } # @level
         }
-        
+
         # @timestamp
         ruby { # convert [app][timestamp] from nanosec-from-epoch number to Datetime
             init => "require 'time'"
@@ -107,4 +146,5 @@ if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
           remove_field => "[app]"
         }
     }
+
 }


### PR DESCRIPTION
This patch restores filters for app events. There are still fields in the app index patterns, dashboards, visualizations, etc., in this repo that use app events, so I'm not sure why the filter was dropped. The relevant commit is https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/commit/e2c7a2ac2b6a487f438a24a058e9e6ae9b88d138, so @cromega might have some insight into that decision. Anyway, we'd like to keep the app events dashboard, so I figured I'd propose restoring these filters.

cc @LinuxBozo 