### PR TITLE
Switch to firehose-to-syslog v2.0.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -19,11 +19,11 @@ ruby-2.3/rubygems-2.6.4.tgz:
   object_id: 40690581-ce13-473c-9cc5-3a459e67be3b
   sha: 8ef39e536af2ecd20b0e7a95765fa6a485087ac8
   size: 478582
-golang/go1.6.3.linux-amd64.tar.gz:
-  object_id: 907ff470-c6df-4779-9e53-bfd2dcf5a613
-  sha: 5e916ba4dd8c2fc43beafca4c08b334c4d0686f3
-  size: 84856920
 cf-cli/cf-cli_6.21.0_linux_x86-64.tgz:
   object_id: 85cfdd26-20b8-4aef-a236-16d027008f00
   sha: 2797ad41eabfec00cadd55164a5dec5d48024f9b
   size: 6542009
+golang/go1.7.linux-amd64.tar.gz:
+  object_id: e0857c0a-e286-426d-8136-81d9edac20a2
+  sha: a744e29da97fc3aadad1ee0d7d89b0d899645e50
+  size: 81573766

--- a/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/jobs/ingestor_cloudfoundry-firehose/spec
@@ -31,8 +31,8 @@ properties:
     description: "The CF API doppler port, defaults to 443"
     default: 443
   cloudfoundry.firehose_events:
-    description: "Comma seperated list of events you would like. Valid options are HttpStop, CounterEvent, Error, Heartbeat, HttpStart, HttpStartStop, LogMessage, ValueMetric, ContainerMetric"
-    default: "LogMessage,Error,ContainerMetric"
+    description: "Comma seperated list of events you would like. Valid options are HttpStop, CounterEvent, Error, HttpStart, HttpStartStop, LogMessage, ValueMetric, ContainerMetric"
+    default: "LogMessage"
 
   syslog.host:
     description: IP or hostname of the syslog drain

--- a/packages/golang/README.md
+++ b/packages/golang/README.md
@@ -6,4 +6,4 @@ The files can be downloaded from the following locations:
 
 | Filename | Download URL |
 | -------- | ------------ |
-| go1.6.2.linux-amd64.tar.gz | [golang.org](https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz) |
+| go1.7.linux-amd64.tar.gz | [golang.org](https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz) |

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -1,4 +1,4 @@
 set -e
 
-tar xzf golang/go1.6.3.linux-amd64.tar.gz
+tar xzf golang/go1.7.linux-amd64.tar.gz
 cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 
 files:
-  - golang/go1.6.3.linux-amd64.tar.gz
+  - golang/go1.7.linux-amd64.tar.gz

--- a/src/logsearch-config/src/logstash-filters/snippets/app-error.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-error.conf
@@ -7,12 +7,6 @@ if( [@type] == "Error" ) {
     mutate {
       add_tag => [ "error" ]
 
-      # firehose-to-syslog names Error.source as "delta" for some reason.
-      # Opened issue: https://github.com/cloudfoundry-community/firehose-to-syslog/issues/114
-      #
-      # Meanwhile rename to original to dropsonde protocol name "source".
-      rename => { "[parsed_json_field][delta]" => "[parsed_json_field][source]" }
-
       rename => { "[parsed_json_field][message]" => "@message" }
     }
 }

--- a/src/logsearch-config/src/logstash-filters/snippets/app-http.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-http.conf
@@ -19,36 +19,6 @@ if( [@type] in ["HttpStart", "HttpStop", "HttpStartStop"] ) {
         }
     }
 
-    ## NOTE: remove this translations as soon as https://github.com/cloudfoundry-community/firehose-to-syslog/issues/115 isfixed
-    # Translate [method]
-    translate {
-      field => "[parsed_json_field][method]"
-      dictionary => [ "1", "GET", "2", "POST", "3", "PUT", "4", "DELETE",	"5", "HEAD",
-                      "6", "ACL", "7", "BASELINE_CONTROL", "8", "BIND",	"9", "CHECKIN",
-                      "10", "CHECKOUT",	"11", "CONNECT", "12", "COPY", "13", "DEBUG",
-                      "14", "LABEL",	"15", "LINK",	"16", "LOCK",	"17", "MERGE", "18", "MKACTIVITY",
-                      "19", "MKCALENDAR",	"20", "MKCOL", "21", "MKREDIRECTREF",	"22", "MKWORKSPACE",
-                      "23", "MOVE",	"24", "OPTIONS", "25", "ORDERPATCH", "26", "PATCH",	"27", "PRI",
-                      "28", "PROPFIND",	"29", "PROPPATCH", "30", "REBIND", "31", "REPORT", "32", "SEARCH",
-                      "33", "SHOWMETHOD",	"34", "SPACEJUMP", "35", "TEXTSEARCH", "36", "TRACE", "37", "TRACK",
-                      "38", "UNBIND",	"39", "UNCHECKOUT",	"40", "UNLINK",	"41", "UNLOCK",	"42", "UPDATE",
-                      "43", "UPDATEREDIRECTREF",	"44", "VERSION_CONTROL"
-      ]
-      destination => "[parsed_json_field][method]"
-      override => true
-      fallback => "NA"
-    }
-
-    # Translate [peer_type]
-    translate {
-      field => "[parsed_json_field][peer_type]"
-      dictionary => [ "1", "Client", "2", "Server" ]
-      destination => "[parsed_json_field][peer_type]"
-      override => true
-      fallback => "NA"
-    }
-    ## endOf NOTE
-
     # Set @message for different Http* event types
     if( [@type] == "HttpStart" ) {
         mutate {

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -255,7 +255,7 @@ describe "App IT" do
 
       sample_event = $app_event_dummy.clone
       sample_event["@message"] = construct_event( "Error", false,
-                                                  {"delta" => "uaa",
+                                                  {"source" => "uaa",
                                                    "code" => 4,
                                                    "level" => "info",
                                                    "msg" => "Error message"})
@@ -284,8 +284,8 @@ describe "App IT" do
                                                    "duration_ms" => 6,
                                                    "instance_id" => "1b1fc66f-9aca-47b1-796c-d9632b23f1b3",
                                                    "instance_index" => 2,
-                                                   "method" => 1,
-                                                   "peer_type" => 2,
+                                                   "method" => "GET",
+                                                   "peer_type" => "Server",
                                                    "remote_addr" => "192.168.111.11:42801",
                                                    "request_id" => "aa694b2c-6e26-4688-4b88-4574aa4e95a5",
                                                    "start_timestamp" => 1471387748611165439,
@@ -329,9 +329,9 @@ describe "App IT" do
       sample_event["@message"] = construct_event( "HttpStart", false,
                                                   {"instance_id" => "1b1fc66f-9aca-47b1-796c-d9632b23f1b3",
                                                    "instance_index" => 2,
-                                                   "method" => 1,
+                                                   "method" => "GET",
                                                    "parent_request_id" => "ghfkgds747jdsfd834hf-dfsdf-4hmjm",
-                                                   "peer_type" => 2,
+                                                   "peer_type" => "Server",
                                                    "remote_addr" => "192.168.111.11:42801",
                                                    "request_id" => "aa694b2c-6e26-4688-4b88-4574aa4e95a5",
                                                    "timestamp" => 1471387748611165439,
@@ -368,7 +368,7 @@ describe "App IT" do
       sample_event = $app_event_dummy.clone
       sample_event["@message"] = construct_event( "HttpStop", false,
                                                   {"content_length" => 38,
-                                                   "peer_type" => 1,
+                                                   "peer_type" => "Client",
                                                    "request_id" => "aa694b2c-6e26-4688-4b88-4574aa4e95a5",
                                                    "status_code" => 200,
                                                    "timestamp" => 1471387748618073991,

--- a/src/logsearch-config/test/logstash-filters/snippets/app-error-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/app-error-spec.rb
@@ -28,7 +28,7 @@ describe "app-error.conf" do
   describe "#fields" do
     when_parsing_log(
         "@type" => "Error",
-        "parsed_json_field" => { "delta" => "abc", "code" => "def", "message" => "Some error message" },
+        "parsed_json_field" => { "source" => "abc", "code" => "def", "message" => "Some error message" },
         "@message" => "some message"
     ) do
 
@@ -36,7 +36,7 @@ describe "app-error.conf" do
 
       it { expect(subject["@message"]).to eq "Some error message" }
       it { expect(subject["parsed_json_field"]["message"]).to be_nil }
-      it { expect(subject["parsed_json_field"]["source"]).to eq "abc" } # delta renamed to source
+      it { expect(subject["parsed_json_field"]["source"]).to eq "abc" }
       it { expect(subject["parsed_json_field"]["code"]).to eq "def" }
 
       it { expect(subject["@type"]).to eq "Error" } # keeps unchanged

--- a/src/logsearch-config/test/logstash-filters/snippets/app-http-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/app-http-spec.rb
@@ -30,7 +30,7 @@ describe "app-http.conf" do
     context "when HttpStart" do
       when_parsing_log(
           "@type" => "HttpStart",
-          "parsed_json_field" => { "method" => 1, "uri" => "/some/uri", "peer_type" => 1,
+          "parsed_json_field" => { "method" => "GET", "uri" => "/some/uri", "peer_type" => "Client",
                                    "instance_id" => "abc", "instance_index" => 5 },
           "@message" => "some message"
       ) do
@@ -39,10 +39,9 @@ describe "app-http.conf" do
 
         it { expect(subject["@message"]).to eq "GET /some/uri" } # constructed
 
-        it { expect(subject["parsed_json_field"]["method"]).to eq "GET" } # translated
-        it { expect(subject["parsed_json_field"]["peer_type"]).to eq "Client" } # translated
-
         # keeps fields
+        it { expect(subject["parsed_json_field"]["method"]).to eq "GET" }
+        it { expect(subject["parsed_json_field"]["peer_type"]).to eq "Client" }
         it { expect(subject["parsed_json_field"]["uri"]).to eq "/some/uri" }
         it { expect(subject["parsed_json_field"]["instance_id"]).to eq "abc" }
         it { expect(subject["parsed_json_field"]["instance_index"]).to eq 5 }
@@ -54,7 +53,7 @@ describe "app-http.conf" do
     context "when HttpStop" do
       when_parsing_log(
           "@type" => "HttpStop",
-          "parsed_json_field" => { "status_code" => 200, "uri" => "/some/uri", "peer_type" => 2,
+          "parsed_json_field" => { "status_code" => 200, "uri" => "/some/uri", "peer_type" => "Server",
                                    "instance_id" => "abc", "instance_index" => 5 },
           "@message" => "some message"
       ) do
@@ -62,9 +61,9 @@ describe "app-http.conf" do
         it { expect(subject["tags"]).to eq ["http"] }
 
         it { expect(subject["@message"]).to eq "200 /some/uri" } # constructed
-        it { expect(subject["parsed_json_field"]["peer_type"]).to eq "Server" } # translated
 
         # keeps fields
+        it { expect(subject["parsed_json_field"]["peer_type"]).to eq "Server" }
         it { expect(subject["parsed_json_field"]["status_code"]).to eq 200 }
         it { expect(subject["parsed_json_field"]["uri"]).to eq "/some/uri" }
         it { expect(subject["parsed_json_field"]["instance_id"]).to eq "abc" }
@@ -77,9 +76,9 @@ describe "app-http.conf" do
     context "when HttpStartStop (and NA peer_type)" do
       when_parsing_log(
           "@type" => "HttpStartStop",
-          "parsed_json_field" => { "method" => 3, "status_code" => 200, "uri" => "/some/uri",
+          "parsed_json_field" => { "method" => "PUT", "status_code" => 200, "uri" => "/some/uri",
                                    "duration_ms" => 300,
-                                   "peer_type" => 3, # NA peer_type
+                                   "peer_type" => "Client",
                                    "instance_id" => "abc", "instance_index" => 5 },
           "@message" => "some message"
       ) do
@@ -88,10 +87,9 @@ describe "app-http.conf" do
 
         it { expect(subject["@message"]).to eq "200 PUT /some/uri (300 ms)" } # constructed
 
-        it { expect(subject["parsed_json_field"]["method"]).to eq "PUT" } # translated
-        it { expect(subject["parsed_json_field"]["peer_type"]).to eq "NA" } # translated
-
         # keeps fields
+        it { expect(subject["parsed_json_field"]["method"]).to eq "PUT" }
+        it { expect(subject["parsed_json_field"]["peer_type"]).to eq "Client" }
         it { expect(subject["parsed_json_field"]["status_code"]).to eq 200 }
         it { expect(subject["parsed_json_field"]["uri"]).to eq "/some/uri" }
         it { expect(subject["parsed_json_field"]["duration_ms"]).to eq 300 }


### PR DESCRIPTION
In this PR we switch to firehose-to-syslog 2.0.0 and go1.7.

Additionally it includes changes in parsing rules, because firehose-to-syslog v2.0.0 contains fixes in fields types/names, so parsing rules were updated accordingly. (fixes included in v2.0.0 are cloudfoundry-community/firehose-to-syslog#115 and cloudfoundry-community/firehose-to-syslog#114.)

Additionally, it sets default events subscription to 'LogMessage' so that we get only logs by default (no metrics).