### PR TITLE
Translate numeric @level to string value

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
@@ -31,10 +31,18 @@ if [@source][component] != "vcap.uaa" and [@source][component] =~ /vcap\..*/ {
 
         } else {
 
-            mutate { convert => { "[parsed_json_field][log_level]" => "string" } }
             mutate {
-              rename => { "[parsed_json_field][log_level]" => "@level" } # @level
               rename => { "[parsed_json_field][message]" => "@message" } # @message
+            }
+
+            # @level
+            translate {
+              field => "[parsed_json_field][log_level]"
+              dictionary => [ "0", "DEBUG", "1", "INFO", "2", "ERROR", "3", "FATAL" ]
+              destination => "@level"
+              override => true
+              fallback => "%{[parsed_json_field][log_level]}"
+              remove_field => "[parsed_json_field][log_level]"
             }
         }
 

--- a/src/logsearch-config/test/logstash-filters/snippets/platform-vcap-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/platform-vcap-spec.rb
@@ -130,4 +130,63 @@ describe "platform-vcap.conf" do
 
   end
 
+  describe "#level translate numeric" do
+
+    context "(DEBUG)" do
+      when_parsing_log(
+          "@source" => {"component" => "vcap.dummy"},
+          "@message" => "{\"log_level\":0}"
+      ) do
+
+        it { expect(subject["@level"]).to eq "DEBUG" } # translated
+
+      end
+    end
+
+    context "(INFO)" do
+      when_parsing_log(
+          "@source" => {"component" => "vcap.dummy"},
+          "@message" => "{\"log_level\":1}"
+      ) do
+
+        it { expect(subject["@level"]).to eq "INFO" } # translated
+
+      end
+    end
+
+    context "(ERROR)" do
+      when_parsing_log(
+          "@source" => {"component" => "vcap.dummy"},
+          "@message" => "{\"log_level\":2}"
+      ) do
+
+        it { expect(subject["@level"]).to eq "ERROR" } # translated
+
+      end
+    end
+
+    context "(FATAL)" do
+      when_parsing_log(
+          "@source" => {"component" => "vcap.dummy"},
+          "@message" => "{\"log_level\":3}"
+      ) do
+
+        it { expect(subject["@level"]).to eq "FATAL" } # translated
+
+      end
+    end
+
+    context "(fallback)" do
+      when_parsing_log(
+          "@source" => {"component" => "vcap.dummy"},
+          "@message" => "{\"log_level\":8}" # unknown log level
+      ) do
+
+        it { expect(subject["@level"]).to eq "8" } # just converted to string
+
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
Some CF components use numeric log levels: 0-DEBUG, 1-INFO, 2-ERROR, 3-FATAL.
When should translate such numeric values to string values accordingly. See original [issue](https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/169) for details.

This PR has changes in platform vcap parsing to translate log level to string values as described above. Original value (converted to string) is used as a fallback for translate.
Plus new test cases in UTs  to check this logic.