### PR TITLE
Make rtr.@message more specific

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -15,17 +15,6 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
 
     if !("fail/cloudfoundry/app-rtr/grok" in [tags]) {
 
-        # Set @level based on HTTP status
-        if [rtr][status] >= 400 {
-            mutate {
-              replace => { "@level" => "ERROR" }
-            }
-        } else {
-            mutate {
-              replace => { "@level" => "INFO" }
-            }
-        }
-
         # Set [rtr][timestamp]
         mutate {
           rename => { "rtr_time" => "[rtr][timestamp]" }
@@ -37,20 +26,36 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
             split => ["[rtr][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
         }
 
-        # Set [rtr][response_time_ms]
-        ruby {
-           code => "event['rtr']['response_time_ms'] = (event['rtr']['response_time_sec']*1000).to_int"
-           remove_field => "response_time_sec"
-        }
-
         # Set [rtr][remote_addr]
         mutate {
           add_field => ["[rtr][remote_addr]", "%{[rtr][x_forwarded_for][0]}"]
         }
         if [rtr][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/ {
-           geoip {
-             source => "[rtr][remote_addr]"
-           }
+            geoip {
+              source => "[rtr][remote_addr]"
+            }
+        }
+
+        # Set [rtr][response_time_ms]
+        ruby {
+           code => "event['rtr']['response_time_ms'] = (event['rtr']['response_time_sec']*1000).to_int"
+           remove_field => "[rtr][response_time_sec]"
+        }
+
+        # Set @message
+        mutate {
+          replace => {"@message" => "%{[rtr][status]} %{[rtr][verb]} %{[rtr][path]} (%{[rtr][response_time_ms]} ms)"}
+        }
+
+        # Set @level (based on HTTP status)
+        if [rtr][status] >= 400 {
+            mutate {
+              replace => { "@level" => "ERROR" }
+            }
+        } else {
+            mutate {
+              replace => { "@level" => "INFO" }
+            }
         }
     }
 

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -90,7 +90,7 @@ describe "App IT" do
                                                   "timestamp" => 1471387745714800488,
                                                   "level" => "debug",
                                                   # RTR message
-                                                  "msg" => 'parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /http HTTP/1.1\" ' +
+                                                  "msg" => 'parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /some/http HTTP/1.1\" ' +
                                                       '200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 ' +
                                                       '(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 ' +
                                                       'x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" ' +
@@ -101,12 +101,7 @@ describe "App IT" do
 
         verify_app_general_fields("app-admin-demo", "LogMessage", "RTR",
                                   # RTR message
-                                  'parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] "GET /http HTTP/1.1" ' +
-                                      '200 0 1413 "-" "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 ' +
-                                      '(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36" 192.168.111.21:35826 ' +
-                                      'x_forwarded_for:"82.209.244.50, 192.168.111.21" x_forwarded_proto:"http" ' +
-                                      'vcap_request_id:831e54f1-f09f-4971-6856-9fdd502d4ae3 response_time:0.005328859 ' +
-                                      'app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n', "INFO")
+                                  '200 GET /some/http (5 ms)', "INFO")
 
         verify_app_cf_fields(99)
 
@@ -121,7 +116,7 @@ describe "App IT" do
           expect(subject["rtr"]["timestamp"]).to eq "15/07/2016:09:26:25 +0000"
           expect(subject["rtr_time"]).to be_nil
           expect(subject["rtr"]["verb"]).to eq "GET"
-          expect(subject["rtr"]["path"]).to eq "/http"
+          expect(subject["rtr"]["path"]).to eq "/some/http"
           expect(subject["rtr"]["http_spec"]).to eq "HTTP/1.1"
           expect(subject["rtr"]["status"]).to eq 200
           expect(subject["rtr"]["request_bytes_received"]).to eq 0
@@ -131,7 +126,6 @@ describe "App IT" do
           expect(subject["rtr"]["x_forwarded_for"]).to eq ["82.209.244.50", "192.168.111.21"]
           expect(subject["rtr"]["x_forwarded_proto"]).to eq "http"
           expect(subject["rtr"]["vcap_request_id"]).to eq "831e54f1-f09f-4971-6856-9fdd502d4ae3"
-          expect(subject["rtr"]["response_time_sec"]).to eq 0.005328859
           # calculated values
           expect(subject["rtr"]["remote_addr"]).to eq "82.209.244.50"
           expect(subject["rtr"]["response_time_ms"]).to eq 5

--- a/src/logsearch-config/test/logstash-filters/snippets/app-logmessage-rtr-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/app-logmessage-rtr-spec.rb
@@ -20,14 +20,14 @@ describe "app-logmessage-rtr.conf" do
           "@source" => { "type" => "RTR" },
           "@level" => "SOME LEVEL",
           # rtr format
-          "@message" => "parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /http HTTP/1.1\" 200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" vcap_request_id:831e54f1-f09f-4971-6856-9fdd502d4ae3 response_time:0.005328859 app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n"
+          "@message" => "parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /some/http HTTP/1.1\" 200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" vcap_request_id:831e54f1-f09f-4971-6856-9fdd502d4ae3 response_time:0.005328859 app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n"
       ) do
 
         # no parsing errors
         it { expect(subject["tags"]).to eq ["logmessage-rtr"] } # no fail tag
 
         # fields
-        it { expect(subject["@message"]).to eq "parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /http HTTP/1.1\" 200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" vcap_request_id:831e54f1-f09f-4971-6856-9fdd502d4ae3 response_time:0.005328859 app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n" }
+        it { expect(subject["@message"]).to eq "200 GET /some/http (5 ms)" }
         it { expect(subject["@level"]).to eq "INFO" }
 
         it "sets [rtr] fields" do
@@ -35,7 +35,7 @@ describe "app-logmessage-rtr.conf" do
           expect(subject["rtr"]["timestamp"]).to eq "15/07/2016:09:26:25 +0000"
           expect(subject["rtr_time"]).to be_nil
           expect(subject["rtr"]["verb"]).to eq "GET"
-          expect(subject["rtr"]["path"]).to eq "/http"
+          expect(subject["rtr"]["path"]).to eq "/some/http"
           expect(subject["rtr"]["http_spec"]).to eq "HTTP/1.1"
           expect(subject["rtr"]["status"]).to eq 200
           expect(subject["rtr"]["request_bytes_received"]).to eq 0
@@ -45,7 +45,6 @@ describe "app-logmessage-rtr.conf" do
           expect(subject["rtr"]["x_forwarded_for"]).to eq ["82.209.244.50", "192.168.111.21"]
           expect(subject["rtr"]["x_forwarded_proto"]).to eq "http"
           expect(subject["rtr"]["vcap_request_id"]).to eq "831e54f1-f09f-4971-6856-9fdd502d4ae3"
-          expect(subject["rtr"]["response_time_sec"]).to eq 0.005328859
           # calculated values
           expect(subject["rtr"]["remote_addr"]).to eq "82.209.244.50"
           expect(subject["rtr"]["response_time_ms"]).to eq 5


### PR DESCRIPTION
Change App RTR logs parsing to set @message field as 
`%{[rtr][status]} %{[rtr][verb]} %{[rtr][path]} (%{[rtr][response_time_ms]} ms)`. 
Update tests accordingly.

(fix for issue https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/166)