### PR TITLE
Add deployment dictionary lookup template

### DIFF
--- a/jobs/logsearch-for-cloudfoundry-filters/spec
+++ b/jobs/logsearch-for-cloudfoundry-filters/spec
@@ -1,8 +1,16 @@
 ---
 name: logsearch-for-cloudfoundry-filters
-templates: {}
 
 packages:
 - logsearch-for-cloudfoundry-filters
 
-properties: {}
+templates:
+  deployment_lookup.yml.erb: config/deployment_lookup.yml
+
+properties:
+  logstash_parser.deployment_name.cf:
+    description: "Name of Cloud Foundry cf deployment. CF jobs are mapped to this value in deployment_lookup.yml dictionary file."
+    default: cloudfoundry-cf
+  logstash_parser.deployment_name.diego:
+    description: "Name of Cloud Foundry diego deployment (if there is one). Diego jobs are mapped to this value in deployment_lookup.yml dictionary file."
+    default: cloudfoundry-diego

--- a/jobs/logsearch-for-cloudfoundry-filters/templates/deployment_lookup.yml.erb
+++ b/jobs/logsearch-for-cloudfoundry-filters/templates/deployment_lookup.yml.erb
@@ -1,0 +1,37 @@
+elasticsearch_data.*: logsearch
+elasticsearch_master.*: logsearch
+firehose-to-syslog.*: logsearch
+ingestor.*: logsearch
+kibana.*: logsearch
+maintenance.*: logsearch
+parser.*: logsearch
+queue.*: logsearch
+monitor.*: logsearch
+ls-router.*: logsearch
+
+consul.*: <%= p('logstash_parser.deployment_name.cf')%>
+ha_proxy.*: <%= p('logstash_parser.deployment_name.cf')%>
+nats.*: <%= p('logstash_parser.deployment_name.cf')%>
+etcd.*: <%= p('logstash_parser.deployment_name.cf')%>
+stats.*: <%= p('logstash_parser.deployment_name.cf')%>
+nfs.*: <%= p('logstash_parser.deployment_name.cf')%>
+blobstore.*: <%= p('logstash_parser.deployment_name.cf')%>
+postgres.*: <%= p('logstash_parser.deployment_name.cf')%>
+uaa.*: <%= p('logstash_parser.deployment_name.cf')%>
+api.*: <%= p('logstash_parser.deployment_name.cf')%>
+clock_global.*: <%= p('logstash_parser.deployment_name.cf')%>
+hm9000.*: <%= p('logstash_parser.deployment_name.cf')%>
+runner.*: <%= p('logstash_parser.deployment_name.cf')%>
+loggregator.*: <%= p('logstash_parser.deployment_name.cf')%>
+doppler.*: <%= p('logstash_parser.deployment_name.cf')%>
+router.*: <%= p('logstash_parser.deployment_name.cf')%>
+acceptance_tests.*: <%= p('logstash_parser.deployment_name.cf')%>
+smoke_tests.*: <%= p('logstash_parser.deployment_name.cf')%>
+
+cell.*: <%= p('logstash_parser.deployment_name.diego')%>
+database.*: <%= p('logstash_parser.deployment_name.diego')%>
+cc_bridge.*: <%= p('logstash_parser.deployment_name.diego')%>
+brain.*: <%= p('logstash_parser.deployment_name.diego')%>
+access.*: <%= p('logstash_parser.deployment_name.diego')%>
+route_emitter.*: <%= p('logstash_parser.deployment_name.diego')%>
+colocated.*: <%= p('logstash_parser.deployment_name.diego')%>

--- a/templates/stub.logsearch-for-cloudfoundry.yml
+++ b/templates/stub.logsearch-for-cloudfoundry.yml
@@ -80,6 +80,10 @@ properties:
     debug: false
     elasticsearch_index: "logs-%{[@metadata][index]}-%{+YYYY.MM.dd}"
     elasticsearch_index_type: "%{@type}"
+    deployment_dictionary: /var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/deployment_lookup.yml
+    deployment_name:
+      cf: cf
+      diego: cf-diego
   syslog:
     host: (( grab jobs.ingestor.networks.[0].static_ips.[0] ))
     port: 5514


### PR DESCRIPTION
Provide deployment dictionary lookup template for CF deployments (both cf and diego). Names of deployments are configurable (cloudfoundry_deployment.* properties).
Set logstash_parser.deployment_dictionary property to path of this dictionary file (job parser) to make logsearch-boshrelease use it to override default dictionary (which contains logsearch deployment only).