### PR TITLE
Add "redirect" parameter when calling UAA /logout.do during Kibana logout.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,4 +116,24 @@ properties:
     port: 5514
 ```
 
+### 9. Update CloudFoundry deployment to include ELK URI to the whitelist of UAA logout redirects
+
+If you've chosen to enable UAA Authentication in Kibana, then make sure to include your ELK URI(s) to the whitelist of URIs that UAA uses to redirect after logout. Update `login.logout.*` properites in your CF deployment like the following:
+
+```
+properties:
+...
+login:
+  logout:
+    redirect:
+      url: /login
+      parameter:
+        disable: false
+        whitelist:
+        - https://my_kibana_domain/login
+        - http://my_kibana_domain/login
+...
+```
+> NOTE: If you skip this step, the UAA authentication will still be working in Kibana, but your ability to get automatically redirected to the Kibana home page after logout will be lost. Read more about [the redirect feature](features.md#redirect-after-logout) if necessary.
+
 </br>[<- prev page](jobs.md) | [next page ->](logs-parsing.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -47,6 +47,24 @@ From technical point of view, the authorization mechanism applies additional fil
 
 The plugin is delivered in Logsearch-for-cloudfoundry deployment with _cf-kibana_ job (case of Kibana deployed to CloudFoundry) and as a plugin installed to standalone Kibana provided by Logsearch deployment.
 
+##### Redirect after logout
+Kibana authentication plugin redirects user to UAA UI for user login and logout accordingly. If you want to get redirected back to the Kibana application after user logout, make sure to enable "redirects after logout" feture in UAA server that you are using. This feature is [disabled](https://github.com/cloudfoundry/uaa/blob/3.9.3/uaa/src/main/webapp/WEB-INF/spring-servlet.xml#L440) by default in UAA. You can enable it in the deployment manifest of your UAA. Example:
+```
+properties:
+...
+login:
+  logout:
+    redirect:
+      url: /login
+      parameter:
+        disable: false
+        whitelist:
+        - https://my_kibana_domain/login
+        - http://my_kibana_domain/login
+...
+```
+(example is built based on the [UAA logout config](https://github.com/cloudfoundry/uaa/blob/3.9.3/uaa/src/main/resources/login.yml#L38-L45) and [UAA-release spec](https://github.com/cloudfoundry/uaa-release/blob/v24/jobs/uaa/spec#L190-L199))
+
 #### Kibana saved objects
 
 Kibana allows to save searches, visualizations, and dashboards and then reuse them when searching data. 

--- a/jobs/cf-kibana/templates/manifest.yml.erb
+++ b/jobs/cf-kibana/templates/manifest.yml.erb
@@ -10,6 +10,7 @@ applications:
   env:
     NODE_ENV: production
     USE_HTTPS: <%= p('cf-kibana.use_https')%>
+    KIBANA_DOMAIN: "<%= p("cf-kibana.app_name") %>.<%= p("cf-kibana.cloudfoundry.system_domain") %>"
     KIBANA_OAUTH2_CLIENT_ID: "<%= p('cf-kibana.oauth2_client_id')%>"
     KIBANA_OAUTH2_CLIENT_SECRET: "<%= p('cf-kibana.oauth2_client_secret')%>"
     CF_API_URI: "https://api.<%= p('cf-kibana.cloudfoundry.system_domain')%>"

--- a/jobs/create-uaa-client/spec
+++ b/jobs/create-uaa-client/spec
@@ -8,7 +8,7 @@ properties:
   create-uaa-client.app_name:
     description: "The Kibana log dashboard app name ( eg defaults to: logs )"
     default: logs
-  create-uaa-client.elk_domain:
+  create-uaa-client.kibana_domain:
     description: "The Kibana dashboard domain. Is used for redirects."
   create-uaa-client.oauth2_client_id:
     description: "The UAA kibana oauth2 client id. Put an existing client id or one you want the job to create."

--- a/jobs/create-uaa-client/templates/bin/run
+++ b/jobs/create-uaa-client/templates/bin/run
@@ -44,7 +44,7 @@ echo "Creating new OAuth2 client: <%= p('create-uaa-client.oauth2_client_id') %>
   "resource_ids" : ["none"],
   "authorized_grant_types" : ["authorization_code", "refresh_token"],
   "access_token_validity": 43200,
-  "redirect_uri": ["https://<%= p('create-uaa-client.elk_domain') %>/login","http://<%= p('create-uaa-client.elk_domain') %>/login"]
+  "redirect_uri": ["https://<%= p('create-uaa-client.kibana_domain') %>/login","http://<%= p('create-uaa-client.kibana_domain') %>/login"]
 }' \
 -X POST https://uaa.<%= p('create-uaa-client.cloudfoundry.system_domain') %>/oauth/clients
 

--- a/src/kibana-cf_authentication/index.js
+++ b/src/kibana-cf_authentication/index.js
@@ -1,219 +1,289 @@
-var Bell = require('bell');
-var AuthCookie = require('hapi-auth-cookie');
+var Bell = require('bell'); // OAuth2.0 authentication library (see https://github.com/hapijs/bell for lib details)
+var AuthCookie = require('hapi-auth-cookie'); // auth strategies mechanism
 var Promise = require('bluebird');
 var request = Promise.promisify(require('request'));
 var uuid = require('uuid');
 
+
+/*
+ --------------------------
+ Authentication mechanism: |
+ --------------------------
+ -- I --
+ All calls by default are guarded by `uaa-cookie` strategy.
+ The strategy checks the following:
+ # 1) If `uaa-auth` cookie is set, then session_id, decoded from it, is verified for existence in the cache.
+ If exists, then the user has already been authenticated. The cached entry stores user auth credentials object (OAuth tokens)
+ and user account details (name, orgs/spaces).
+ # 2) If the cookie is not set, or cache verification fails, then the user has to be authenticated first.
+ The user is redirected to /login for authentication.
+
+ -- II --
+ /login call is guarded by `uaa-oauth` strategy.
+ In this strategy we perform OAuth2 authentication using UAA server. Bell lib (https://github.com/hapijs/bell) is used for implementation.
+ Authorization flow:
+ 1) obtain client authorization code
+ 2) obtain user token (access token, refresh token etc.)
+ 3) obtain user profile (delegates to configured provider.profile function)
+
+ provider.profile function is implemented to
+ 1) obtain user account details, orgs/spaces
+ 2) store user credentials (OAuth tokens) and account (name, orgs/spaces) details into the cache.
+ Key for a cache entry is just a generated uuid given as a session_id for that user session.
+
+ Handler for /login call validates if a user has been authenticated successfully and if so,
+ it sets `uaa-auth` cookie with the value of the user session_id.
+ */
+
 module.exports = function (kibana) {
   return new kibana.Plugin({
 
-  uiExports: {
-    app: {
-      title: 'User',
-      main: 'plugins/authentication/user',
-      icon: 'plugins/authentication/user_icon.png',
+    uiExports: {
+      app: {
+        title: 'User',
+        main: 'plugins/authentication/user',
+        icon: 'plugins/authentication/user_icon.png',
 
-      autoload: [].concat(kibana.autoload.styles, 'ui/chrome', 'angular')
-    }
-
-  },
-
-  /*
-  This will set the name of the plugin and will be used by the server for
-  namespacing purposes in the configuration. In Hapi you can expose methods and
-  objects to the system via `server.expose()`. Access to these attributes are done
-  via `server.plugins.<name>.<attribute>`. See the `elasticsearch` plugin for an
-  example of how this is done. If you omit this attribute then the plugin loader
-  will try to set it to the name of the parent folder.
-  */
-  name: 'authentication',
-
-  /*
-  This is an array of plugin names this plugin depends on. These are guaranteed
-  to load before the init() method for this plugin is executed.
-  */
-  require: [],
-
-  /*
-  This method is executed to create a Joi schema for the plugin.
-  The Joi module is passed to every config method and config methods can return promises
-  if they need to execute an async operation before setting the defaults. If you're
-  returning a promise then you should resolve the promise with the Joi schema.
-  */
-  config: function (Joi) {
-    var client_id = (process.env.KIBANA_OAUTH2_CLIENT_ID) ? process.env.KIBANA_OAUTH2_CLIENT_ID : 'client_id';
-    var client_secret = (process.env.KIBANA_OAUTH2_CLIENT_SECRET) ? process.env.KIBANA_OAUTH2_CLIENT_SECRET : 'client_secret';
-    var skip_ssl_validation = (process.env.SKIP_SSL_VALIDATION) ? (process.env.SKIP_SSL_VALIDATION.toLowerCase() === 'true') : false;
-    var cf_system_org = (process.env.CF_SYSTEM_ORG) ? process.env.CF_SYSTEM_ORG : 'system';
-    var cloudFoundryApiUri = (process.env.CF_API_URI) ? process.env.CF_API_URI.replace(/\/$/, '') : 'unknown';
-    var use_redis_sessions = (process.env.REDIS_HOST) ? true : false;
-    var redis_host = (process.env.REDIS_HOST) ? process.env.REDIS_HOST : '127.0.0.1';
-    var redis_port = (process.env.REDIS_PORT) ? process.env.REDIS_PORT : '6379';
-    var cfInfoUri = cloudFoundryApiUri + '/v2/info';
-    var sessionExpirationMs = (process.env.SESSION_EXPIRATION_MS) ? process.env.SESSION_EXPIRATION_MS : 12 * 60 * 60 * 1000; // 12 hours by default
-
-    if (skip_ssl_validation) {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-    }
-
-    //Fetch location of login server, then set config
-    return request(cfInfoUri).spread(function (response, body) {
-
-      var cf_info = JSON.parse(body);
-
-      return Joi.object({
-        enabled: Joi.boolean().default(true),
-        client_id: Joi.string().default(client_id),
-        client_secret: Joi.string().default(client_secret),
-        skip_ssl_validation: Joi.boolean().default(skip_ssl_validation),
-        cf_system_org: Joi.string().default(cf_system_org),
-        authorization_uri: Joi.string().default(cf_info.authorization_endpoint + '/oauth/authorize'),
-        logout_uri: Joi.string().default(cf_info.authorization_endpoint + '/logout.do'),
-        token_uri: Joi.string().default(cf_info.token_endpoint + '/oauth/token'),
-        account_info_uri: Joi.string().default(cf_info.token_endpoint + '/userinfo'),
-        organizations_uri: Joi.string().default(cloudFoundryApiUri + '/v2/organizations'),
-        spaces_uri: Joi.string().default(cloudFoundryApiUri + '/v2/spaces'),
-        random_passphrase: Joi.string().default(client_secret.split('').reverse().join('')),
-        use_redis_sessions: Joi.boolean().default(use_redis_sessions),
-        redis_host: Joi.string().default(redis_host),
-        redis_port: Joi.string().default(redis_port),
-        session_expiration_ms: Joi.number().integer().default(sessionExpirationMs)
-      }).default();
-
-    }).catch(function (error) {
-      console.log('ERROR fetching CF info from ' + cfInfoUri + ' : ' + error);
-      return Joi.object({
-        enabled: Joi.boolean().default(true)
-      }).default();
-    });
-
-  },
-
-  /*
-  The init method is where all the magic happens. It's essentially the same as the
-  register method for a Hapi plugin except it uses promises instead of a callback
-  pattern. Just return a promise when you execute an async operation.
-  */
-  init: function (server, options) {
-    var config = server.config();
-    var isSecure = (process.env.USE_HTTPS) ? process.env.USE_HTTPS : true;
-
-    server.log(['debug', 'authentication'], JSON.stringify(config.get('authentication')));
-
-    server.register([Bell, AuthCookie], function (err) {
-
-      if (err) {
-        server.log(['error', 'authentication'], JSON.stringify(err));
-        return;
+        autoload: [].concat(kibana.autoload.styles, 'ui/chrome', 'angular')
       }
 
-      // Setup the cache for session data
-      var cache_expiration = config.get('authentication.session_expiration_ms'); // session TTL (auth cache expiration)
-      var cache_segment = 'sessions';
-      // Default to memory cache
-      var cache = server.cache({
-        segment: cache_segment,
-        expiresIn: cache_expiration
+    },
+
+    /*
+     This will set the name of the plugin and will be used by the server for
+     namespacing purposes in the configuration. In Hapi you can expose methods and
+     objects to the system via `server.expose()`. Access to these attributes are done
+     via `server.plugins.<name>.<attribute>`. See the `elasticsearch` plugin for an
+     example of how this is done. If you omit this attribute then the plugin loader
+     will try to set it to the name of the parent folder.
+     */
+    name: 'authentication',
+
+    /*
+     This is an array of plugin names this plugin depends on. These are guaranteed
+     to load before the init() method for this plugin is executed.
+     */
+    require: [],
+
+    /*
+     This method is executed to create a Joi schema for the plugin.
+     The Joi module is passed to every config method and config methods can return promises
+     if they need to execute an async operation before setting the defaults. If you're
+     returning a promise then you should resolve the promise with the Joi schema.
+     */
+    config: function (Joi) {
+      var useHttps = (process.env.USE_HTTPS) ? process.env.USE_HTTPS : true
+      var client_id = (process.env.KIBANA_OAUTH2_CLIENT_ID) ? process.env.KIBANA_OAUTH2_CLIENT_ID : 'client_id';
+      var client_secret = (process.env.KIBANA_OAUTH2_CLIENT_SECRET) ? process.env.KIBANA_OAUTH2_CLIENT_SECRET : 'client_secret';
+      var skip_ssl_validation = (process.env.SKIP_SSL_VALIDATION) ? (process.env.SKIP_SSL_VALIDATION.toLowerCase() === 'true') : false;
+      var cf_system_org = (process.env.CF_SYSTEM_ORG) ? process.env.CF_SYSTEM_ORG : 'system';
+      var cloudFoundryApiUri = (process.env.CF_API_URI) ? process.env.CF_API_URI.replace(/\/$/, '') : 'unknown';
+      var logout_redirect_uri = (process.env.KIBANA_DOMAIN) ?
+        ((useHttps) ? 'https://' : 'http://') + process.env.KIBANA_DOMAIN + '/login' : '';
+      var use_redis_sessions = (process.env.REDIS_HOST) ? true : false;
+      var redis_host = (process.env.REDIS_HOST) ? process.env.REDIS_HOST : '127.0.0.1';
+      var redis_port = (process.env.REDIS_PORT) ? process.env.REDIS_PORT : '6379';
+      var cfInfoUri = cloudFoundryApiUri + '/v2/info';
+      var sessionExpirationMs = (process.env.SESSION_EXPIRATION_MS) ? process.env.SESSION_EXPIRATION_MS : 12 * 60 * 60 * 1000; // 12 hours by default
+
+      if (skip_ssl_validation) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+      }
+
+      //Fetch location of login server, then set config
+      return request(cfInfoUri).spread(function (response, body) {
+
+        var cf_info = JSON.parse(body);
+
+        return Joi.object({
+          enabled: Joi.boolean().default(true),
+          client_id: Joi.string().default(client_id),
+          client_secret: Joi.string().default(client_secret),
+          skip_ssl_validation: Joi.boolean().default(skip_ssl_validation),
+          cf_system_org: Joi.string().default(cf_system_org),
+          authorization_uri: Joi.string().default(cf_info.authorization_endpoint + '/oauth/authorize'),
+          logout_uri: Joi.string().default(cf_info.authorization_endpoint + '/logout.do' +
+            /* Set 'redirect' parameter if logout_redirect_uri property is set to get back to Kibana app after logout.
+             (note that redirects after logout should be also enabled in UAA - e.g. https://github.com/cloudfoundry/uaa/blob/3.9.3/uaa/src/main/resources/login.yml#L38-L45)*/
+            ((logout_redirect_uri != '') ? '?redirect=' + logout_redirect_uri : '')),
+          token_uri: Joi.string().default(cf_info.token_endpoint + '/oauth/token'),
+          account_info_uri: Joi.string().default(cf_info.token_endpoint + '/userinfo'),
+          organizations_uri: Joi.string().default(cloudFoundryApiUri + '/v2/organizations'),
+          spaces_uri: Joi.string().default(cloudFoundryApiUri + '/v2/spaces'),
+          random_passphrase: Joi.string().default(client_secret.split('').reverse().join('')),
+          use_redis_sessions: Joi.boolean().default(use_redis_sessions),
+          redis_host: Joi.string().default(redis_host),
+          redis_port: Joi.string().default(redis_port),
+          session_expiration_ms: Joi.number().integer().default(sessionExpirationMs),
+          use_https: Joi.boolean().default(useHttps)
+        }).default();
+
+      }).catch(function (error) {
+        console.log('ERROR fetching CF info from ' + cfInfoUri + ' : ' + error);
+        return Joi.object({
+          enabled: Joi.boolean().default(true)
+        }).default();
       });
-      // If possible, use redis for cache. Requires REDIS_HOST defined in environment
-      if (config.get('authentication.use_redis_sessions')) {
-        var policy = { expiresIn: cache_expiration };
-        var options = {
-          host: config.get('authentication.redis_host'),
-          port: config.get('authentication.redis_port'),
-          partition: 'kibana'
-        };
-        var Catbox = require('catbox');
-        var client = new Catbox.Client(require('catbox-redis'), options);
-        client.start(function(err) {
-          if (err) {
-            server.log(['err', 'cache', 'redis'], err);
-          }
-          cache = new Catbox.Policy(policy, client, cache_segment);
+
+    },
+
+    /*
+     The init method is where all the magic happens. It's essentially the same as the
+     register method for a Hapi plugin except it uses promises instead of a callback
+     pattern. Just return a promise when you execute an async operation.
+     */
+    init: function (server, options) {
+      var config = server.config();
+
+      server.log(['debug', 'authentication'], JSON.stringify(config.get('authentication')));
+
+      server.register([Bell, AuthCookie], function (err) {
+
+        if (err) {
+          server.log(['error', 'authentication'], JSON.stringify(err));
+          return;
+        }
+
+        var isSecure = config.get('authentication.use_https');
+
+        /* Setup the cache to store user authenticated sessions. */
+        var cache_expiration = config.get('authentication.session_expiration_ms'); // session TTL (auth cache expiration)
+        var cache_segment = 'sessions';
+        // Default to memory cache
+        var cache = server.cache({
+          segment: cache_segment,
+          expiresIn: cache_expiration
         });
-      }
-
-      server.auth.strategy('uaa-cookie', 'cookie', {
-        password: config.get('authentication.random_passphrase'), //Password used for encryption
-        cookie: 'uaa-auth', // Name of cookie to set
-        redirectTo: '/login',
-        validateFunc: function(request, session, callback) {
-          cache.get(session.session_id, function(err, cached) {
+        // If possible, use redis for cache. Requires REDIS_HOST defined in environment
+        if (config.get('authentication.use_redis_sessions')) {
+          var policy = { expiresIn: cache_expiration };
+          var options = {
+            host: config.get('authentication.redis_host'),
+            port: config.get('authentication.redis_port'),
+            partition: 'kibana'
+          };
+          var Catbox = require('catbox');
+          var client = new Catbox.Client(require('catbox-redis'), options);
+          client.start(function(err) {
             if (err) {
-              server.log(['error', 'authentication', 'session:validation'], JSON.stringify(err));
-              return callback(err, false);
+              server.log(['err', 'cache', 'redis'], err);
             }
-            if (!cached) {
-              return callback(null, false);
-            }
-            return callback(null, true, cached.credentials);
+            cache = new Catbox.Policy(policy, client, cache_segment);
           });
-        },
-        isSecure: isSecure,
-        ttl: config.get('authentication.session_expiration_ms') // session TTL (cookie expiration)
-      });
+        }
 
-      var uaaProvider = {
-        protocol: 'oauth2',
-        auth: config.get('authentication.authorization_uri'),
-        token: config.get('authentication.token_uri'),
-        scope: ['openid', 'oauth.approvals', 'scim.userids', 'cloud_controller.read'],
-        profile: function (credentials, params, get, callback) {
-          server.log(['debug', 'authentication'],  JSON.stringify({ thecredentials: credentials, theparams: params }));
-          var account = {};
-          credentials.session_id = uuid.v1();
-          get(config.get('authentication.account_info_uri'), null, function (profile) {
-            server.log(['debug', 'authentication'], JSON.stringify({ theprofile: profile }));
-            account.profile = {
-              id: profile.id,
-              username: profile.username,
-              displayName: profile.name,
-              email: profile.email,
-              raw: profile
-            };
+        /* Add `uaa-cookie` authentication startegy.
+         In this strategy we validate that
+         1) 'uaa-auth' cookie is set in a request,
+         2) session_id decoded from the cookie exists in the cache of authenticated sessions
+         (the cache contains pairs session_id <- {credentials, account}).
 
-            get(config.get('authentication.organizations_uri'), null, function(orgs) {
-              server.log(['debug', 'authentication', 'orgs'], JSON.stringify(orgs));
-              account.orgIds = orgs.resources.map(function(resource) { return resource.metadata.guid; });
-              account.orgs = orgs.resources.map(function(resource) { return resource.entity.name; });
+         If the validation fails we reply 'unauthorized' and redirect to /login for user authentication.
+         (for the strategy logic see hapi-auth-cookie/lib/index.js authenticate function)
+         */
+        server.auth.strategy('uaa-cookie', 'cookie', {
+          password: config.get('authentication.random_passphrase'), // Password used for encryption
+          cookie: 'uaa-auth', // Name of cookie to set
+          redirectTo: '/login', // unauthenticated users are redirected to this url
+          validateFunc: function(request, session, callback) {
+            cache.get(session.session_id, function(err, cached) { // session.session_id is retrieved from the uaa-auth cookie
+              if (err) {
+                server.log(['error', 'authentication', 'session:validation'], JSON.stringify(err));
+                return callback(err, false);
+              }
+              if (!cached) {
+                return callback(null, false);
+              }
+              return callback(null, true, cached.credentials);
+            });
+          },
+          isSecure: isSecure,
+          ttl: config.get('authentication.session_expiration_ms') // session TTL (cookie expiration)
+        });
 
-              get(config.get('authentication.spaces_uri'), null, function(spaces) {
-                server.log(['debug', 'authentication', 'spaces'], JSON.stringify(spaces));
-                account.spaceIds = spaces.resources.map(function(resource) { return resource.metadata.guid; });
-                account.spaces = spaces.resources.map(function(resource) { return resource.entity.name; });
-                cache.set(credentials.session_id, {credentials: credentials, account: account}, 0, function(err) {
-                  if (err) {
-                    server.log(['error', 'authentication', 'session:set'], JSON.stringify(err));
-                  }
-                  return callback();
+        /* Define authentication provider for `uaa-oauth` strategy. */
+        var uaaProvider = {
+          protocol: 'oauth2',
+          auth: config.get('authentication.authorization_uri'),
+          token: config.get('authentication.token_uri'),
+          scope: ['openid', 'oauth.approvals', 'scim.userids', 'cloud_controller.read'],
+          /* Function for obtaining user profile (is called after obtaining user access token in bell/lib/oauth.js v2 function).
+           Here we get user account details (profile, orgs/spaces) and store it and user credentials (Oauth tokens) in the cache.
+           We use generated session_id as a key when storing user data in the cache.
+           */
+          profile: function (credentials, params, get, callback) {
+            server.log(['debug', 'authentication'],  JSON.stringify({ thecredentials: credentials, theparams: params }));
+            var account = {};
+
+            // generate user session_id, set it to auth credentials
+            credentials.session_id = uuid.v1();
+
+            // get user account details
+            get(config.get('authentication.account_info_uri'), null, function (profile) {
+              server.log(['debug', 'authentication'], JSON.stringify({ theprofile: profile }));
+              account.profile = {
+                id: profile.id,
+                username: profile.username,
+                displayName: profile.name,
+                email: profile.email,
+                raw: profile
+              };
+
+              // get user orgs
+              get(config.get('authentication.organizations_uri'), null, function(orgs) {
+                server.log(['debug', 'authentication', 'orgs'], JSON.stringify(orgs));
+                account.orgIds = orgs.resources.map(function(resource) { return resource.metadata.guid; });
+                account.orgs = orgs.resources.map(function(resource) { return resource.entity.name; });
+
+                // get user spaces
+                get(config.get('authentication.spaces_uri'), null, function(spaces) {
+                  server.log(['debug', 'authentication', 'spaces'], JSON.stringify(spaces));
+                  account.spaceIds = spaces.resources.map(function(resource) { return resource.metadata.guid; });
+                  account.spaces = spaces.resources.map(function(resource) { return resource.entity.name; });
+
+                  // store user data in the cache
+                  cache.set(credentials.session_id, {credentials: credentials, account: account}, 0, function(err) {
+                    if (err) {
+                      server.log(['error', 'authentication', 'session:set'], JSON.stringify(err));
+                    }
+                    return callback();
+                  });
                 });
               });
             });
-          });
-        }
-      };
+          }
+        };
 
-      server.auth.strategy('uaa-oauth', 'bell', {
-        provider: uaaProvider,
-        password: config.get('authentication.random_passphrase'), //Password used for encryption
-        clientId: config.get('authentication.client_id'),
-        clientSecret: config.get('authentication.client_secret'),
-        forceHttps: isSecure,
-        isSecure: isSecure
-      });
+        /* Add `uaa-oauth` authentication startegy. Performs OAuth2 authentication using configured authentication provider.
+         (see bell/lib/oauth.js exports.v2)
+         */
+        server.auth.strategy('uaa-oauth', 'bell', {
+          provider: uaaProvider,
+          password: config.get('authentication.random_passphrase'), //Password used for encryption
+          clientId: config.get('authentication.client_id'),
+          clientSecret: config.get('authentication.client_secret'),
+          forceHttps: isSecure,
+          isSecure: isSecure
+        });
 
-      server.auth.default('uaa-cookie');
+        server.auth.default('uaa-cookie'); // all cals by default are guarded by `uaa-cookie` strategy
 
-      server.route([{
+        server.route([{
+          /* Endpoint for users authentication. Unauthenticated users are redirected to it
+           for user authentication (see configuration of `uaa-cookie` strategy).
+           Is guarded by `uaa-oauth` strategy which triggers OAuth user authentiction using UAA.
+           Sets `uaa-auth` cookie if the user has been authenticated successfully.
+           */
           method: 'GET',
           path: '/login',
           config: {
-            auth: 'uaa-oauth',
+            auth: 'uaa-oauth', // /login is guarded by `uaa-oauth` strategy
             handler: function (request, reply) {
               if (request.auth.isAuthenticated) {
+                /* Sets uaa-auth cookie with value of user auth session_id.
+                 (see request.auth.session definition in hapi-auth-cookie/lib/index.js) */
                 var session_id = '' + request.auth.credentials.session_id;
                 request.auth.session.set({ session_id: session_id });
-                //request.auth.session.set(request.auth.credentials);
                 return reply.redirect('/');
               }
               reply('Not logged in...').code(401);
@@ -236,10 +306,22 @@ module.exports = function (kibana) {
           method: 'GET',
           path: '/logout',
           config: {
-            auth: false,
             handler: function (request, reply) {
+
+              // remove user session entry from the cache
+              cache.drop(request.auth.credentials.session_id, function (err) {
+                if (err) {
+                  server.log(['error', 'authentication', 'session:logout'], JSON.stringify(err));
+                }
+              });
+
+              /* Clears `uaa-auth` cookie.
+               (see request.auth.session definition in hapi-auth-cookie/lib/index.js)
+               */
               request.auth.session.clear();
-              reply.redirect(config.get('authentication.logout_uri'));
+
+              /* Redirect to UAA logout. */
+              reply.redirect(config.get("authentication.logout_uri"));
             }
           }
         }, {
@@ -327,25 +409,25 @@ module.exports = function (kibana) {
             }
           }
         }
-      ]);
+        ]);
 
-    }); // end: server.register
+      }); // end: server.register
 
-    // Redirect _msearch and _search through our own route so we can modify the payload
-    server.ext('onRequest', function (request, reply) {
-      if (/elasticsearch\/_msearch/.test(request.path) && !request.auth.artifacts) {
-        request.setUrl('/_filtered_msearch');
-      } else {
-        var match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path);
-        if (match !== null && !request.auth.artifacts) {
-          request.setUrl('/' + match[1] + '/_filtered_search');
+      // Redirect _msearch and _search through our own route so we can modify the payload
+      server.ext('onRequest', function (request, reply) {
+        if (/elasticsearch\/_msearch/.test(request.path) && !request.auth.artifacts) {
+          request.setUrl('/_filtered_msearch');
+        } else {
+          var match = /elasticsearch\/([^\/]+)\/_search/.exec(request.path);
+          if (match !== null && !request.auth.artifacts) {
+            request.setUrl('/' + match[1] + '/_filtered_search');
+          }
         }
-      }
-      return reply.continue();
+        return reply.continue();
 
-    }); // end server.ext('onRequest')
+      }); // end server.ext('onRequest')
 
-  }
+    }
 
   });
 };

--- a/templates/logsearch-for-cf.example-with-uaa-auth.yml
+++ b/templates/logsearch-for-cf.example-with-uaa-auth.yml
@@ -57,7 +57,7 @@ jobs:
   resource_pool: errand
   properties:
     create-uaa-client:
-      elk_domain: my_elk.domain  # The Kibana dashboard domain. Is used for redirects. (Technically, it should be set with your ls-router IP)
+      kibana_domain: my_kibana.domain  # The Kibana dashboard domain. Is used for redirects. (Technically, it should be set with your ls-router IP)
       oauth2_client_id: my_kibana_client_id  # The UAA kibana oauth2 client id. Put an existing client id or one you want the job to create. Default value: kibana_oauth2_client
       oauth2_client_secret: my_kibana_client_password  # The UAA kibana oauth2 client id's secret
       cloudfoundry:
@@ -89,6 +89,7 @@ jobs:
   properties:
     kibana:
       env:
+      - KIBANA_DOMAIN: (( grab jobs.create-uaa-client.properties.create-uaa-client.kibana_domain ))
       - KIBANA_OAUTH2_CLIENT_ID: (( grab jobs.create-uaa-client.properties.create-uaa-client.oauth2_client_id  ))
       - KIBANA_OAUTH2_CLIENT_SECRET: (( grab jobs.create-uaa-client.properties.create-uaa-client.oauth2_client_secret ))
       - SKIP_SSL_VALIDATION: (( grab jobs.ingestor.properties.cloudfoundry.skip_ssl_validation ))


### PR DESCRIPTION
Redirect to Kibana /login after logout. Implemented using "redirect" parameter of UAA "/logout.do" endpoint. NOTE, that to work normally, redirects after logout should be enabled in UAA - https://github.com/cloudfoundry/uaa/blob/3.9.3/uaa/src/main/resources/login.yml#L38-L45.
Also add useful comments to kibana-cf_authentication plugin.