### PR TITLE
Support authentication via UAA client.

### DIFF
--- a/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/jobs/ingestor_cloudfoundry-firehose/spec
@@ -25,8 +25,16 @@ properties:
     default: false
   cloudfoundry.firehose_user:
     description: "CF UAA username of user with 'doppler.firehose' permissions"
+    default: ""
   cloudfoundry.firehose_password:
     description: "CF UAA password of user with 'doppler.firehose' permissions"
+    default: ""
+  cloudfoundry.firehose_client_id:
+    description: "CF UAA client ID with 'doppler.firehose' permissions"
+    default: ""
+  cloudfoundry.firehose_client_secret:
+    description: "CF UAA client secret with 'doppler.firehose' permissions"
+    default: ""
   cloudfoundry.firehose_port:
     description: "The CF API doppler port, defaults to 443"
     default: 443

--- a/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -53,6 +53,8 @@ case $1 in
         <% if p("cloudfoundry.skip_ssl_validation") %>--skip-ssl-validation <% end %> \
         --user=<%= p("cloudfoundry.firehose_user") %> \
         --password=<%= p("cloudfoundry.firehose_password") %> \
+        --client-id=<%= p("cloudfoundry.firehose_client_id") %> \
+        --client-secret=<%= p("cloudfoundry.firehose_client_secret") %> \
         --syslog-protocol=<%= p("syslog.protocol") %>\
         --syslog-server=<%= p("syslog.host") %>:<%= p("syslog.port") %>\
         --events=<%= p("cloudfoundry.firehose_events") %> \


### PR DESCRIPTION
Useful for avoiding password expiration on user accounts.

Depends on
https://github.com/cloudfoundry-community/firehose-to-syslog/pull/133
and https://github.com/cloudfoundry-community/go-cfclient/pull/36.