### PR TITLE
Add custom filters option

### DIFF
--- a/jobs/logsearch-for-cloudfoundry-filters/templates/logstash-filters-custom.conf.erb
+++ b/jobs/logsearch-for-cloudfoundry-filters/templates/logstash-filters-custom.conf.erb
@@ -1,0 +1,1 @@
+<%= p('logstash_parser.custom_filters').empty? ? ' ' :  p('logstash_parser.custom_filters')  %>

--- a/jobs/parser-config-lfc/spec
+++ b/jobs/parser-config-lfc/spec
@@ -6,6 +6,7 @@ packages:
 
 templates:
   deployment_lookup.yml.erb: config/deployment_lookup.yml
+  logstash-filters-custom.conf.erb: config/logstash-filters-custom.conf
 
 properties:
   logstash_parser.deployment_name.cf:
@@ -14,3 +15,8 @@ properties:
   logstash_parser.deployment_name.diego:
     description: "Name of Cloud Foundry diego deployment (if there is one). Diego jobs are mapped to this value in deployment_lookup.yml dictionary file."
     default: cloudfoundry-diego
+  logstash_parser.custom_filters:
+    description: |
+      Custom logstash filters that will be appended to the logstash filters list.
+      Populates the file /var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf
+    default: ""


### PR DESCRIPTION
Allow passing new logstash filters directly from the new
logstash_parser.custom_filters property. The whole string
is written to file
/var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf
The path must be loaded via property logstash_parser.filters similarly to
how logstash-filters-default.conf is loaded in
https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/cf69a408b36dce4a474b03f04c4e6b0027f89d21/docs/customization.md#parsing-rules

My organisation (GDS) has already signed the CF CLA. Do we need to sign this Altoros CLA as well? This is would be a legal hurdle for us.