### PR TITLE
Load default index to Kibana 4.5.4

### DIFF
--- a/src/logsearch-config/src/kibana-objects/config/4.5.4.json.erb
+++ b/src/logsearch-config/src/kibana-objects/config/4.5.4.json.erb
@@ -1,0 +1,4 @@
+{
+  "buildNum": 10000,
+  "defaultIndex": "logs-app-*"
+}


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/213.