### PR TITLE
adds working rtr message pattern for cf release v252+

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -14,6 +14,9 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
       # cf-release v250+
       match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"(%{HOSTPORT}|-)\" \"(%{HOSTPORT}|-)\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[rtr][vcap_request_id]} response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}" ]
 
+      # cf-release v252+
+      match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]}\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"%{BASE10NUM:[rtr][app][index]:int}\""]
+
       tag_on_failure => [ "fail/cloudfoundry/app-rtr/grok" ]
     }
 

--- a/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/it/app-it-spec.rb
@@ -90,18 +90,16 @@ describe "App IT" do
                                                   "timestamp" => 1471387745714800488,
                                                   "level" => "debug",
                                                   # RTR message
-                                                  "msg" => 'parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /some/http HTTP/1.1\" ' +
-                                                      '200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 ' +
-                                                      '(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 ' +
-                                                      'x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" ' +
-                                                      'vcap_request_id:831e54f1-f09f-4971-6856-9fdd502d4ae3 response_time:0.005328859 ' +
-                                                      'app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\\\n'})
+                                                  "msg" => 'parser.64.78.234.207.xip.io - [2017-03-16T13:28:25.166+0000] \"GET / HTTP/1.1\" ' + 
+                                                           '200 0 1677 \"-\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36\" ' +
+                                                           '\"10.2.9.104:60079\" \"10.2.32.71:61010\" x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"https\" ' +
+                                                           'vcap_request_id:\"f322dd76-aacf-422e-49fb-c73bc46ce45b\" response_time:0.001602684 app_id:\"27c02dec-80ce-4af6-94c5-2b51848edae9\" app_index:\"1\"\\\n'})
 
       when_parsing_log(sample_event) do
 
         verify_app_general_fields("app-admin-demo", "LogMessage", "RTR",
                                   # RTR message
-                                  '200 GET /some/http (5 ms)', "INFO")
+                                  '200 GET / (1 ms)', "INFO")
 
         verify_app_cf_fields(99)
 
@@ -113,22 +111,28 @@ describe "App IT" do
 
         it "sets [rtr] fields" do
           expect(subject["rtr"]["hostname"]).to eq "parser.64.78.234.207.xip.io"
-          expect(subject["rtr"]["timestamp"]).to eq "15/07/2016:09:26:25 +0000"
+          expect(subject["rtr"]["timestamp"]).to eq "2017-03-16T13:28:25.166+0000"
           expect(subject["rtr_time"]).to be_nil
           expect(subject["rtr"]["verb"]).to eq "GET"
-          expect(subject["rtr"]["path"]).to eq "/some/http"
+          expect(subject["rtr"]["path"]).to eq "/"
           expect(subject["rtr"]["http_spec"]).to eq "HTTP/1.1"
           expect(subject["rtr"]["status"]).to eq 200
           expect(subject["rtr"]["request_bytes_received"]).to eq 0
-          expect(subject["rtr"]["body_bytes_sent"]).to eq 1413
+          expect(subject["rtr"]["body_bytes_sent"]).to eq 1677
           expect(subject["rtr"]["referer"]).to eq "-"
-          expect(subject["rtr"]["http_user_agent"]).to eq "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+          expect(subject["rtr"]["http_user_agent"]).to eq "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36"
           expect(subject["rtr"]["x_forwarded_for"]).to eq ["82.209.244.50", "192.168.111.21"]
-          expect(subject["rtr"]["x_forwarded_proto"]).to eq "http"
-          expect(subject["rtr"]["vcap_request_id"]).to eq "831e54f1-f09f-4971-6856-9fdd502d4ae3"
+          expect(subject["rtr"]["x_forwarded_proto"]).to eq "https"
+          expect(subject["rtr"]["vcap_request_id"]).to eq "f322dd76-aacf-422e-49fb-c73bc46ce45b"
+          expect(subject["rtr"]["src"]["host"]).to eq "10.2.9.104"
+          expect(subject["rtr"]["src"]["port"]).to eq "60079"
+          expect(subject["rtr"]["dst"]["host"]).to eq "10.2.32.71"
+          expect(subject["rtr"]["dst"]["port"]).to eq "61010"
+          expect(subject["rtr"]["app"]["id"]).to eq "27c02dec-80ce-4af6-94c5-2b51848edae9"
+          expect(subject["rtr"]["app"]["index"]).to eq 1
           # calculated values
           expect(subject["rtr"]["remote_addr"]).to eq "82.209.244.50"
-          expect(subject["rtr"]["response_time_ms"]).to eq 5
+          expect(subject["rtr"]["response_time_ms"]).to eq 1
         end
 
         it "sets geoip for [rtr][remote_addr]" do

--- a/src/logsearch-config/test/logstash-filters/snippets/app-logmessage-rtr-spec.rb
+++ b/src/logsearch-config/test/logstash-filters/snippets/app-logmessage-rtr-spec.rb
@@ -103,6 +103,59 @@ describe "app-logmessage-rtr.conf" do
 
         end
       end
+    end
+
+    context "RTR format (cf-release v252+)" do
+
+      context "" do
+        when_parsing_log(
+            "@type" => "LogMessage",
+            "@source" => { "type" => "RTR" },
+            "@level" => "SOME LEVEL",
+            # rtr format - quoted requestRemoteAddr and destIPandPort
+            "@message" => "parser.64.78.234.207.xip.io - [2017-03-16T13:28:25.166+0000] \"GET / HTTP/1.1\" 200 0 1677 \"-\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36\" \"10.2.9.104:60079\" \"10.2.32.71:61010\" x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"https\" vcap_request_id:\"f322dd76-aacf-422e-49fb-c73bc46ce45b\" response_time:0.001602684 app_id:\"27c02dec-80ce-4af6-94c5-2b51848edae9\" app_index:\"1\"\n"
+        ) do
+
+          # no parsing errors
+          it { expect(subject["tags"]).to eq ["logmessage-rtr"] } # no fail tag
+
+          # fields
+          it { expect(subject["@message"]).to eq "200 GET / (1 ms)" }
+          it { expect(subject["@level"]).to eq "INFO" }
+
+          it "sets [rtr] fields" do
+            expect(subject["rtr"]["hostname"]).to eq "parser.64.78.234.207.xip.io"
+            expect(subject["rtr"]["timestamp"]).to eq "2017-03-16T13:28:25.166+0000"
+            expect(subject["rtr_time"]).to be_nil
+            expect(subject["rtr"]["verb"]).to eq "GET"
+            expect(subject["rtr"]["path"]).to eq "/"
+            expect(subject["rtr"]["http_spec"]).to eq "HTTP/1.1"
+            expect(subject["rtr"]["status"]).to eq 200
+            expect(subject["rtr"]["request_bytes_received"]).to eq 0
+            expect(subject["rtr"]["body_bytes_sent"]).to eq 1677
+            expect(subject["rtr"]["referer"]).to eq "-"
+            expect(subject["rtr"]["http_user_agent"]).to eq "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36"
+            expect(subject["rtr"]["x_forwarded_for"]).to eq ["82.209.244.50", "192.168.111.21"]
+            expect(subject["rtr"]["x_forwarded_proto"]).to eq "https"
+            expect(subject["rtr"]["vcap_request_id"]).to eq "f322dd76-aacf-422e-49fb-c73bc46ce45b"
+            expect(subject["rtr"]["src"]["host"]).to eq "10.2.9.104"
+            expect(subject["rtr"]["src"]["port"]).to eq "60079"
+            expect(subject["rtr"]["dst"]["host"]).to eq "10.2.32.71"
+            expect(subject["rtr"]["dst"]["port"]).to eq "61010"
+            expect(subject["rtr"]["app"]["id"]).to eq "27c02dec-80ce-4af6-94c5-2b51848edae9"
+            expect(subject["rtr"]["app"]["index"]).to eq 1
+            # calculated values
+            expect(subject["rtr"]["remote_addr"]).to eq "82.209.244.50"
+            expect(subject["rtr"]["response_time_ms"]).to eq 1
+          end
+
+          it "sets geoip for [rtr][remote_addr]" do
+            expect(subject["geoip"]).not_to be_nil
+            expect(subject["geoip"]["ip"]).to eq "82.209.244.50"
+          end
+
+        end
+      end
 
       context "empty requestRemoteAddr and destIPandPort" do
         when_parsing_log(


### PR DESCRIPTION
I found the cf-release v250+ RTR grok pattern to not working with v252 and v253. With the help of http://grokdebug.herokuapp.com I adjusted the pattern so that it works. 

