### PR TITLE
Drop unused ingestor settings.

### DIFF
--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -18,16 +18,16 @@ properties:
   cf-kibana.app_instances:
     description: "Count of Kibana instances"
     default: 1
-    
+
   cf-kibana.oauth2_use_existing_client:
     description: "Set true to use existing UAA oauth2 client for Kibana. Note the client required scopes: `openid,oauth.approvals,scim.userids,cloud_controller.read`."
-    default: false  
+    default: false
   cf-kibana.oauth2_client_id:
     description: "The UAA Kibana oauth2 client id"
     default: kibana_oauth2_client
   cf-kibana.oauth2_client_secret:
     description: "Password to be used for the UAA kibana oauth2 client"
-  
+
   cf-kibana.cloudfoundry.logsearch_space:
     description: "CF space where Kibana will be deployed"
     default: logsearch
@@ -39,18 +39,18 @@ properties:
   cf-kibana.cloudfoundry.apps_domain:
     description: "The CF apps domain ( eg: apps.10.244.0.34.xip.io )"
   cf-kibana.cloudfoundry.api_security_group:
-    description: "CF security group with API access"  
+    description: "CF security group with API access"
   cf-kibana.cloudfoundry.uaa_admin_client_id:
     description: "The UAA admin client id (required scope is `uaa.admin`). The admin client is used to manage the UAA Kibana oauth2 client."
   cf-kibana.cloudfoundry.uaa_admin_client_secret:
-    description: "The UAA admin client's secret" 
-  
+    description: "The UAA admin client's secret"
+
   cf-kibana.elasticsearch.host:
     description: "ElasticSearch master endpoint"
   cf-kibana.elasticsearch.port:
     description: "ElasticSearch master port"
     default: 9200
-  
+
   cf-kibana.logging_quiet:
     description: "Set to true to suppress all logging output other than error messages"
     default: true

--- a/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/jobs/ingestor_cloudfoundry-firehose/spec
@@ -35,9 +35,6 @@ properties:
   cloudfoundry.firehose_client_secret:
     description: "CF UAA client secret with 'doppler.firehose' permissions"
     default: ""
-  cloudfoundry.firehose_port:
-    description: "The CF API doppler port, defaults to 443"
-    default: 443
   cloudfoundry.firehose_events:
     description: "Comma seperated list of events you would like to get. Valid options are CounterEvent,Error,HttpStartStop,LogMessage,ValueMetric,ContainerMetric"
     default: "LogMessage"

--- a/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -49,7 +49,7 @@ case $1 in
 
     exec chpst -u vcap:vcap firehose-to-syslog \
         --api-endpoint=<%= p("cloudfoundry.api_endpoint") %> \
-        --doppler-endpoint=<%= p("cloudfoundry.doppler_endpoint") %> \
+        <% if_p("cloudfoundry.doppler_endpoint") do |endpoint| %>--doppler-endpoint=<%= endpoint %><% end %> \
         <% if p("cloudfoundry.skip_ssl_validation") %>--skip-ssl-validation <% end %> \
         --user=<%= p("cloudfoundry.firehose_user") %> \
         --password=<%= p("cloudfoundry.firehose_password") %> \

--- a/templates/stub.ingestor-only.yml
+++ b/templates/stub.ingestor-only.yml
@@ -15,7 +15,6 @@ jobs:
 properties:
   cloudfoundry:
     firehose_password: admin
-    firehose_port: 443
     firehose_user: admin
     skip_ssl_validation: true
     system_domain: 10.244.0.34.xip.io

--- a/templates/stub.logsearch-for-cf.cf-kibana.yml
+++ b/templates/stub.logsearch-for-cf.cf-kibana.yml
@@ -21,7 +21,7 @@ jobs:
         index_type: "%{@type}"
       filters:
       - logsearch-for-cf: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
-      deployment_dictionary: 
+      deployment_dictionary:
       - /var/vcap/packages/logsearch-config/deployment_lookup.yml
       - /var/vcap/jobs/parser-config-lfc/config/deployment_lookup.yml
       deployment_name:
@@ -74,7 +74,7 @@ jobs:
       host: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
       port: 9200
     cloudfoundry:
-      firehose_events: (( grab properties.cloudfoundry.firehose_events ))  
+      firehose_events: (( grab properties.cloudfoundry.firehose_events ))
     kibana_objects:
       upload_predefined_kibana_objects: true # Default value. Whether to upload Kibana objects predefined in this job or not.
       upload_data_files: []  # List of text files to put in API endpoint /_bulk
@@ -82,7 +82,6 @@ jobs:
 properties:
   cloudfoundry:
     api_endpoint: https://api.my_sys.cf.example
-    doppler_endpoint: wss://doppler.my_sys.cf.example
     firehose_user: my_admin_user  # CF UAA username of user with 'doppler.firehose' permissions
     firehose_password: my_admin_password  # CF UAA password of user with 'doppler.firehose' permissions
     firehose_events: LogMessage  # Default value. Comma seperated list of events you would like to get. Valid options are CounterEvent,Error,HttpStartStop,LogMessage,ValueMetric,ContainerMetric.

--- a/templates/stub.logsearch-for-cf.standalone-kibana-with-auth.yml
+++ b/templates/stub.logsearch-for-cf.standalone-kibana-with-auth.yml
@@ -12,7 +12,6 @@ jobs:
   properties:
     cloudfoundry:
       api_endpoint: https://api.VAR_CF_DOMAIN
-      doppler_endpoint: wss://doppler.VAR_CF_DOMAIN
       firehose_user: admin  # CF UAA username of user with 'doppler.firehose' permissions
       firehose_password: VAR_CF_SECRET  # CF UAA password of user with 'doppler.firehose' permissions
       firehose_events: LogMessage  # Default value. Comma seperated list of events you would like to get. Valid options are CounterEvent,Error,HttpStartStop,LogMessage,ValueMetric,ContainerMetric.


### PR DESCRIPTION
* Drop unused port variable
* Make doppler override optional

The `firehose-to-syslog` package will use the doppler endpoint from `/v2/info` unless the user passes an override. Since that will be what users want most of the time, this patch makes the doppler override optional in `logsearch-for-cloudfoundry` as well.

cc @LinuxBozo 