### PR TITLE
makes cc-pull-time parameter configurable

### DIFF
--- a/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/jobs/ingestor_cloudfoundry-firehose/spec
@@ -41,6 +41,9 @@ properties:
   cloudfoundry.firehose_subscription_id:
     description: "ID for the firehose-to-syslog subscription"
     default: "firehose"
+  cloudfoundry.firehose_cc_pull_interval:
+    description: "full app metadata update interval; defaults to 60s"
+    default: "60s"
 
   syslog.host:
     description: IP or hostname of the syslog drain

--- a/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
+++ b/jobs/ingestor_cloudfoundry-firehose/templates/bin/ingestor_cloudfoundry-firehose_ctl
@@ -60,7 +60,7 @@ case $1 in
         --events=<%= p("cloudfoundry.firehose_events") %> \
         --subscription-id=<%= p("cloudfoundry.firehose_subscription_id") %> \
         --boltdb-path=$TMP_DIR/firehose-to-syslog.cache.db \
-        --cc-pull-time=60s \<% if p("ingestor_cloudfoundry-firehose.debug") %>
+        --cc-pull-time=<%= p("cloudfoundry.firehose_cc_pull_interval") %> \<% if p("ingestor_cloudfoundry-firehose.debug") %>
         --debug \<% end%>
          >>$LOG_DIR/$JOB_NAME.stdout.log \
          2>>$LOG_DIR/$JOB_NAME.stderr.log


### PR DESCRIPTION
Enables configuration of full app metadata update interval via deployment manifest