### PR TITLE
Allow operators to skip client creation.

### DIFF
--- a/jobs/ingestor_cloudfoundry-firehose/spec
+++ b/jobs/ingestor_cloudfoundry-firehose/spec
@@ -30,7 +30,6 @@ properties:
     default: "firehose-to-syslog"
   cloudfoundry.firehose_client_secret:
     description: "CF UAA client secret with 'doppler.firehose' permissions"
-    default: ""
   cloudfoundry.firehose_events:
     description: "Comma seperated list of events you would like to get. Valid options are CounterEvent,Error,HttpStartStop,LogMessage,ValueMetric,ContainerMetric"
     default: "LogMessage"

--- a/jobs/ingestor_cloudfoundry-firehose/templates/bin/pre-start.erb
+++ b/jobs/ingestor_cloudfoundry-firehose/templates/bin/pre-start.erb
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+<% if_p("create-uaa-client.cloudfoundry.system_domain", "create-uaa-client.cloudfoundry.uaa_admin_client_id", "create-uaa-client.cloudfoundry.uaa_admin_client_secret") do %>
+
 ACCESS_TOKEN=$(\
 curl -s -D - -k \
 -u <%= p('create-uaa-client.cloudfoundry.uaa_admin_client_id')%>:<%= p('create-uaa-client.cloudfoundry.uaa_admin_client_secret')%> \
@@ -36,3 +38,5 @@ echo "Creating new OAuth2 client: <%= p('cloudfoundry.firehose_client_id') %>"
   "authorized_grant_types" : ["client_credentials", "refresh_token"]
 }' \
 -X POST https://uaa.<%= p('create-uaa-client.cloudfoundry.system_domain') %>/oauth/clients
+
+<% end %>


### PR DESCRIPTION
The latest release required operators to add admin UAA credentials to create an ingestor client. We prefer to create UAA clients in a separate pipeline so that we don't have to use admin accounts in this deployment. This patch makes the admin credentials optional and only attempts to create a new client if admin credentials are provided.