### PR TITLE
Use templated index for smoke tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## unreleased
+### Changed
+- Build smoke test index using go templates
+
+## v203.0.0
+### Changed
+- Create properties mappings for static fields to define their types (https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/168)
+
 ## v202.0.0
 ### Changed
 - Make prefix of index pattern in ES settings/mappings configurable
@@ -8,7 +16,3 @@
 - Use uaa\_admin\_client\_id instead of hardcode when acquire token
 - Fix infinite redirect loop when uaa-oauth cookie > 4K
 - Better documentation
-
-## v203.0.0
-### Changed
-- Create properties mappings for static fields to define their types (https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/168)

--- a/jobs/smoke-tests/spec
+++ b/jobs/smoke-tests/spec
@@ -29,4 +29,4 @@ properties:
     default: 9200
   smoke_tests.elasticsearch_master.app_index:
     description: App index name
-    default: logs-app
+    default: 'logs-app-{{.Org}}-{{.Space}}-{{.Time.Format \"2006.01.02\"}}'


### PR DESCRIPTION
Goes with https://github.com/cloudfoundry-community/logsearch-smoke-tests/pull/2. Note--will need to update submodule before merge.