### PR TITLE
Disable development console by default.

### DIFF
--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -72,6 +72,9 @@ properties:
   cf-kibana.plugins:
     description: "a list of key-value pairs of plugins. e.g. Kibana-auth: /var/vcap/packagaes/kibana/kibana-auth"
     default: []
+  cf-kibana.console_enabled:
+    description: "Enable Kibana development console; should be set to `false` in a multi-tenant deployment."
+    default: false
   cf-kibana.config_options:
     description: "Additional options to append to kibana configuration (YAML format)."
     default: ~

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -84,4 +84,7 @@ logging.quiet: <%= p("cf-kibana.logging_quiet") %>
 # and all requests.
 # logging.verbose: true
 
+# Configure development console
+console.enabled: <%= p("cf-kibana.console_enabled") %>
+
 <% if_p('cf-kibana.config_options') do | v | %><%= v %><% end %>


### PR DESCRIPTION
The development console should be disabled for multi-tenant deployments. It's possible to disable the console using `cf-kibana.config_options`, but IMO it's safer to expose as a separate option and default to `false` so that operators don't enable the console by accident.

If this makes sense, we might want to make a similar change for the kibana job on logsearch-boshrelease. Otherwise, we can just update the templates here using `config_options`. WDYT @Infra-Red ?