### PR TITLE
Update cf-kibana run command for fewer error messages and quicker failures

### DIFF
--- a/jobs/cf-kibana/templates/manifest.yml.erb
+++ b/jobs/cf-kibana/templates/manifest.yml.erb
@@ -5,7 +5,7 @@ applications:
   instances: <%= p('cf-kibana.app_instances')%>
   domain: <%= p('cf-kibana.cloudfoundry.apps_domain')%>
   buildpack: binary_buildpack
-  command: bash -c "\$HOME/bin/kibana --port \$PORT & pid=\$!; while true; do [ \$(ps uh \$pid | awk '{print \$6}') -gt 300000 ] && { echo memory limit reached, recycling instance; exit 1; }; sleep 1; done"
+  command: bash -c "\$HOME/bin/kibana --port \$PORT & pid=\$!; while true; do process=\$(ps uh \$pid | awk '{print \$6}'); [ -z \$process ] && { echo exiting due to kibana failure... >&2; exit 1; }; [ ${process:-0} -eq 300000 ] && { echo memory limit reached, recycling instance >&2; exit 1; }; sleep 1; done"
   timeout: 180
   env:
     NODE_ENV: production


### PR DESCRIPTION
Currently if cf-kibana crashes, or has issues during startup, the app will get stuck an an infinite loop, spitting out errors of`ERR bash: line 0: [: -gt: unary operator expected`. Eventually this removes useful logging from `cf logs logs --recent` output, making it hard to troubleshoot.

This PR addresses that, so that the errors do not show up. It also updates the loop to bail out quickly if no cf-kibana app is found, and moves error messaging to STDERR to show up red in `cf logs` output.

