### PR TITLE
Add custom filters option

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -44,6 +44,29 @@ Note that the latter possibility overrides Logsearch-for-cloudfoundry parsing ru
 
 Please do mind **the order** of parsing rules you specify.
 
+You can add custom parsing rules via manifest property `logstash_parser.custom_filters` directly. This will
+populate the file `logstash-filters-custom.conf` which must be loaded as above. Example:
+
+```yaml
+- name: parser
+  properties:
+    logstash_parser:
+      filters:
+      - logsearch-for-cf: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
+      - my-custom-filters: /var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf
+      custom_filters:
+        if [@source][component] == "vcap_nginx_access" {
+          grok {
+            match => {
+              "@message" =>
+                '%{IPORHOST:[nginx][clientip]} - \[%{HTTPDATE:[nginx][timestamp]}\]
+                [...]
+                vcap_request_id:%{UUID:[nginx][vcap_request_id]} response_time:%{NUMBER:[nginx][response_time]}'
+            }
+          }
+        }
+```
+
 #### Elasticsearch mappings
 
 Elasticsearch mappings can be customized via `elasticsearch_config.templates` property of `maintenance` job:

--- a/jobs/parser-config-lfc/spec
+++ b/jobs/parser-config-lfc/spec
@@ -6,6 +6,7 @@ packages:
 
 templates:
   deployment_lookup.yml.erb: config/deployment_lookup.yml
+  logstash-filters-custom.conf.erb: config/logstash-filters-custom.conf
 
 properties:
   logstash_parser.deployment_name.cf:
@@ -14,3 +15,8 @@ properties:
   logstash_parser.deployment_name.diego:
     description: "Name of Cloud Foundry diego deployment (if there is one). Diego jobs are mapped to this value in deployment_lookup.yml dictionary file."
     default: cloudfoundry-diego
+  logstash_parser.custom_filters:
+    description: |
+      Custom logstash filters that will be appended to the logstash filters list.
+      Populates the file /var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf
+    default: ""

--- a/jobs/parser-config-lfc/templates/logstash-filters-custom.conf.erb
+++ b/jobs/parser-config-lfc/templates/logstash-filters-custom.conf.erb
@@ -1,0 +1,1 @@
+<%= p('logstash_parser.custom_filters').empty? ? ' ' :  p('logstash_parser.custom_filters')  %>


### PR DESCRIPTION
Allow passing new logstash filters directly from the new logstash_parser.custom_filters property. The whole string is written to file:
`/var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf`

The path must be loaded via property logstash_parser.filters similarly to how `logstash-filters-default.conf` is loaded in:
https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/develop/docs/customization.md#parsing-rules

This change was originally proposed in https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/211 but couldn't go ahead because of a licensing issue. The PR is now raised from my personal repo to work around that.
Also, it has been been rebased against latest develop, fixed (commit a8331b28fe1a490e9c7de1eebfdcaff97f6ea1cc changed a few paths) and the new feature has been documented.