### PR TITLE
Set cpu percentage to float.

### DIFF
--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -6,7 +6,6 @@
 
 require 'json'
 
-
 string_default = { "type": "string", "index": "not_analyzed" }.to_json
 
 %>
@@ -14,10 +13,9 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
   "template" : "<%= p('elasticsearch_config.app_index_prefix') %>*",
   "order": 203,
   "mappings" : {
-    
     <%# ------------ App specific types %>
     "LogMessage": {
-      "properties": {              
+      "properties": {
         "@cf": {
           "type": "object",
           "dynamic": true,
@@ -90,10 +88,10 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "location": { "type": "geo_point" },
             "timezone": <%= string_default %>
           }
-        }         
+        }
       }
     },
-    
+
     "ContainerMetric": {
       "properties": {
         "@cf": {
@@ -117,12 +115,12 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "memory_bytes":       { "type": "long" },
             "disk_bytes_quota":   { "type": "long" },
             "disk_bytes":         { "type": "long" },
-            "cpu_percentage":     { "type": "long" }
+            "cpu_percentage":     { "type": "scaled_float", "scaling_factor": 100 }
           }
         }
       }
     },
-    
+
     "ValueMetric": {
       "properties": {
         "valuemetric": {
@@ -133,10 +131,10 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
             "name":  <%= string_default %>,
             "value": { "type": "long" }
           }
-        }                 
+        }
       }
     },
-    
+
     "CounterEvent": {
       "properties": {
         "counterevent": {
@@ -150,7 +148,7 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
         }
       }
     },
-    
+
     "Error": {
       "properties": {
         "error": {
@@ -163,7 +161,7 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
         }
       }
     },
-    
+
     "HttpStartStop": {
       "properties": {
         "@cf": {
@@ -200,6 +198,5 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
         }
       }
     }
-        
   }
 }


### PR DESCRIPTION
The `cpu_percentage` field should be a float, but it's currently indexed as an int. I haven't been able to confirm this yet, but I'm guessing that this is causing problems with aggregations using this field--for example, the app metrics dashboard doesn't seem to work at the moment due to a problem with this field.