### PR TITLE
Cookie passphrase

### DIFF
--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -57,6 +57,8 @@ properties:
   cf-kibana.session_expiration_ms:
     description: "Kibana user session expiration period in milliseconds (default to 12h)"
     default: 43200000
+  cf-kibana.session_key:
+    description: "Session cookie encryption passphrase; should be >=32 bytes long"
   cf-kibana.default_app_id:
     description: "The default application to load"
     default: "dashboard/App-Overview"

--- a/jobs/cf-kibana/spec
+++ b/jobs/cf-kibana/spec
@@ -58,7 +58,7 @@ properties:
     description: "Kibana user session expiration period in milliseconds (default to 12h)"
     default: 43200000
   cf-kibana.session_key:
-    description: "Session cookie encryption passphrase; should be >=32 bytes long"
+    description: "Session cookie encryption passphrase; must be >=32 bytes long"
   cf-kibana.default_app_id:
     description: "The default application to load"
     default: "dashboard/App-Overview"

--- a/jobs/cf-kibana/templates/manifest.yml.erb
+++ b/jobs/cf-kibana/templates/manifest.yml.erb
@@ -18,3 +18,4 @@ applications:
     SKIP_SSL_VALIDATION: <%= p('cloudfoundry.skip_ssl_validation')%>
     REDIS_HOST: <%= p('redis.host')%>
     SESSION_EXPIRATION_MS: <%= p('cf-kibana.session_expiration_ms')%>
+    <%= if_p('cf-kibana.session_key') do |key| %>SESSION_KEY: <%= key %><% end %>

--- a/jobs/cf-kibana/templates/manifest.yml.erb
+++ b/jobs/cf-kibana/templates/manifest.yml.erb
@@ -18,4 +18,7 @@ applications:
     SKIP_SSL_VALIDATION: <%= p('cloudfoundry.skip_ssl_validation')%>
     REDIS_HOST: <%= p('redis.host')%>
     SESSION_EXPIRATION_MS: <%= p('cf-kibana.session_expiration_ms')%>
-    <%= if_p('cf-kibana.session_key') do |key| %>SESSION_KEY: <%= key %><% end %>
+    <%= if_p('cf-kibana.session_key') do |key| %>
+    <% raise ArgumentError, "session key must have length >= 32" unless key.size >= 32 %>
+    SESSION_KEY: <%= key %>
+    <% end %>

--- a/jobs/kibana-auth-plugin/spec
+++ b/jobs/kibana-auth-plugin/spec
@@ -29,6 +29,8 @@ properties:
   kibana-auth.session_expiration_ms:
     description: "Kibana user session expiration period in milliseconds (default to 12h)"
     default: 43200000
+  kibana-auth.session_key:
+    description: "Session cookie encryption passphrase; should be >=32 bytes long"
   kibana-auth.redis_host:
     description: Redis host address
   kibana-auth.redis_port:

--- a/jobs/kibana-auth-plugin/spec
+++ b/jobs/kibana-auth-plugin/spec
@@ -30,7 +30,7 @@ properties:
     description: "Kibana user session expiration period in milliseconds (default to 12h)"
     default: 43200000
   kibana-auth.session_key:
-    description: "Session cookie encryption passphrase; should be >=32 bytes long"
+    description: "Session cookie encryption passphrase; must be >=32 bytes long"
   kibana-auth.redis_host:
     description: Redis host address
   kibana-auth.redis_port:

--- a/jobs/kibana-auth-plugin/templates/config/config.sh.erb
+++ b/jobs/kibana-auth-plugin/templates/config/config.sh.erb
@@ -5,6 +5,7 @@ export KIBANA_OAUTH2_CLIENT_ID="<%= p("kibana-auth.cloudfoundry.client_id") %>"
 export KIBANA_OAUTH2_CLIENT_SECRET="<%= p("kibana-auth.cloudfoundry.client_secret") %>"
 export CF_SYSTEM_ORG="<%= p("kibana-auth.cloudfoundry.system_org") %>"
 export SESSION_EXPIRATION_MS="<%= p("kibana-auth.session_expiration_ms") %>"
+<% if_p("kibana-auth.session_key") do |key| %>export SESSION_KEY="<%= key %>"<% end %>
 export REDIS_HOST="<%= p("kibana-auth.redis_host") %>"
 export REDIS_PORT="<%= p("kibana-auth.redis_port") %>"
 export KIBANA_DOMAIN="<%= p("kibana-auth.app_name") %>.<%= p("kibana-auth.cloudfoundry.system_domain")%>"

--- a/jobs/kibana-auth-plugin/templates/config/config.sh.erb
+++ b/jobs/kibana-auth-plugin/templates/config/config.sh.erb
@@ -5,7 +5,11 @@ export KIBANA_OAUTH2_CLIENT_ID="<%= p("kibana-auth.cloudfoundry.client_id") %>"
 export KIBANA_OAUTH2_CLIENT_SECRET="<%= p("kibana-auth.cloudfoundry.client_secret") %>"
 export CF_SYSTEM_ORG="<%= p("kibana-auth.cloudfoundry.system_org") %>"
 export SESSION_EXPIRATION_MS="<%= p("kibana-auth.session_expiration_ms") %>"
-<% if_p("kibana-auth.session_key") do |key| %>export SESSION_KEY="<%= key %>"<% end %>
 export REDIS_HOST="<%= p("kibana-auth.redis_host") %>"
 export REDIS_PORT="<%= p("kibana-auth.redis_port") %>"
 export KIBANA_DOMAIN="<%= p("kibana-auth.app_name") %>.<%= p("kibana-auth.cloudfoundry.system_domain")%>"
+
+<% if_p("kibana-auth.session_key") do |key| %>
+<% raise ArgumentError, "session key must have length >= 32" unless key.size >= 32 %>
+export SESSION_KEY="<%= key %>"
+<% end %>

--- a/src/kibana-cf_authentication/index.js
+++ b/src/kibana-cf_authentication/index.js
@@ -80,7 +80,7 @@ module.exports = function (kibana) {
       var redis_port = (process.env.REDIS_PORT) ? process.env.REDIS_PORT : '6379';
       var cfInfoUri = cloudFoundryApiUri + '/v2/info';
       var sessionExpirationMs = (process.env.SESSION_EXPIRATION_MS) ? process.env.SESSION_EXPIRATION_MS : 12 * 60 * 60 * 1000; // 12 hours by default
-      var random_string = randomstring.generate(40);
+      var random_string = process.env.SESSION_KEY || randomstring.generate(40);
 
       if (skip_ssl_validation) {
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';


### PR DESCRIPTION
Currently, each kibana instance generates its own random cookie password on start, so if multiple instances are used, cookies encrypted by one instance can't be decrypted by any other instance, which breaks the ouath login flow. This patch allows operators to set a cookie password that will be shared across instances. If not set, the auth plugin falls back to the current behavior of a random password per instance.

I'm not sure if this is related to #251, but the traceback from @tomsherrod looks very similar to what we observed here.

cc @linuxbozo @cnelson @wjwoodson