### PR TITLE
Expose settings in index templates.

### DIFF
--- a/jobs/elasticsearch-config-lfc/spec
+++ b/jobs/elasticsearch-config-lfc/spec
@@ -23,3 +23,10 @@ properties:
     description: |
       Name prefix of your `platform` log indices. If you don't split `app` and `platform` indices, then just set it with the value of `elasticsearch_config.index_prefix`.
     default: "logs-platform"
+
+  elasticsearch_config.index_settings:
+    description: Index settings for logs
+  elasticsearch_config.app_index_settings:
+    description: Index settings for app logs
+  elasticsearch_config.platform_index_settings:
+    description: Index settings for platform logs

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-app.json.erb
@@ -11,6 +11,7 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
 %>
 {
   "template" : "<%= p('elasticsearch_config.app_index_prefix') %>*",
+  "settings": <%= p('elasticsearch_config.app_index_settings', {}).to_json %>,
   "order": 203,
   "mappings" : {
     <%# ------------ App specific types %>

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings-platform.json.erb
@@ -12,11 +12,10 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
 %>
 {
   "template" : "<%= p('elasticsearch_config.platform_index_prefix') %>*",
+  "settings": <%= p('elasticsearch_config.platform_index_settings', {}).to_json %>,
   "order": 204,
   "mappings" : {
-            
     <%# ------------ Platform specific types %>
-
     "_default_": {
       "properties": {
         "geoip"  : {
@@ -25,10 +24,10 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
           "properties" : {
             "location" : { "type" : "geo_point" }
           }
-        }     
+        }
       }
     },
-    
+
     "uaa": {
       "properties": {
         "uaa": {
@@ -55,7 +54,7 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
         }
       }
     },
-    
+
     "haproxy": {
       "properties": {
         "haproxy": {
@@ -94,6 +93,5 @@ string_default = { "type": "string", "index": "not_analyzed" }.to_json
         }
       }
     }
-        
   }
 }

--- a/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
+++ b/jobs/elasticsearch-config-lfc/templates/index-mappings.json.erb
@@ -15,7 +15,7 @@ full_text_with_raw_copy = {
   "type": "string",
   "index": "analyzed",
   "norms": { "enabled": false },
-  "fields": {            
+  "fields": {
     "raw": {
       "type": "string",
       "index": "not_analyzed",
@@ -28,16 +28,15 @@ full_text_with_raw_copy = {
 %>
 {
   "template" : "<%= p('elasticsearch_config.index_prefix') %>*",
-  "order": 202,  
+  "settings": <%= p('elasticsearch_config.index_settings', {}).to_json %>,
+  "order": 202,
   "mappings" : {
-
     <%# --------------  Default type (applied to all types) %>
-    
     "_default_" : {
       "properties" : {
-         
+
          <%# ------  common fields %>
-            
+
          "tags":        <%= string_default %>,
          "@input":      <%= string_default %>,
          "@index_type": <%= string_default %>,
@@ -45,16 +44,16 @@ full_text_with_raw_copy = {
          "@timestamp":  { "type": "date" },
          "@message":    <%= full_text_with_raw_copy %>,
          "@level":      <%= string_default %>,
-               
+
          "@shipper": {
            "type": "object",
            "dynamic": true,
            "properties": {
              "name":     <%= string_default %>,
-             "priority": { "type": "long" }             
+             "priority": { "type": "long" }
            }
          },
-      
+
          "@source": {
            "type": "object",
            "dynamic": true,
@@ -69,8 +68,7 @@ full_text_with_raw_copy = {
              "vm":         <%= string_default %>
            }
          }
-         
       }
-    }    
+    }
   }
 }


### PR DESCRIPTION
For example, so that operators can set up slow query logging.

cc @cnelson 