### PR TITLE
UAA Redirects to Kibana on wrong domain

### DIFF
--- a/jobs/cf-kibana/templates/errand.sh.erb
+++ b/jobs/cf-kibana/templates/errand.sh.erb
@@ -86,7 +86,7 @@ echo "Creating new OAuth2 client: <%= p("cf-kibana.oauth2_client_id") %>"
   "resource_ids" : ["none"],
   "authorized_grant_types" : ["authorization_code", "refresh_token"],
   "access_token_validity": 43200,
-  "redirect_uri": ["https://<%= p("cf-kibana.app_name") %>.<%= p("cf-kibana.cloudfoundry.system_domain") %>/login", "http://<%= p("cf-kibana.app_name") %>.<%= p("cf-kibana.cloudfoundry.system_domain") %>/login"]
+  "redirect_uri": ["https://<%= p("cf-kibana.app_name") %>.<%= p("cf-kibana.cloudfoundry.apps_domain") %>/login", "http://<%= p("cf-kibana.app_name") %>.<%= p("cf-kibana.cloudfoundry.apps_domain") %>/login"]
 }' \
 -X POST https://uaa.<%= p("cf-kibana.cloudfoundry.system_domain") %>/oauth/clients
 <% end %>


### PR DESCRIPTION
The cf-kibana job's manifest.yml uses the CF apps domain for the Kibana app (i.e. logs.apps.cf.com) rather than the system domain.   But this UAA redirect assumes the Kibana app is available from the system domain.    This means UAA redirects will fail.

It's possible that the alternative behavior would be to push the Kibana CF app to a route on the system domain itself rather than the apps domain (which should be a private domain owned by the CF system org).   That's how we worked around this in our install.