### PR TITLE
Adds a feature to skip authorization

### DIFF
--- a/jobs/kibana-auth-plugin/templates/config/config.sh.erb
+++ b/jobs/kibana-auth-plugin/templates/config/config.sh.erb
@@ -32,6 +32,7 @@ export SESSION_EXPIRATION_MS="<%= p("kibana-auth.session_expiration_ms") %>"
 export REDIS_HOST="<%= redis_host %>"
 export REDIS_PORT="<%= redis_port %>"
 export KIBANA_DOMAIN="<%= p("kibana-auth.app_name") %>.<%= system_domain %>"
+export SKIP_AUTHORIZATION="<%= p("kibana-auth.skip_authorization") %>"
 
 <% if_p("kibana-auth.session_key") do |key| %>
 <% raise ArgumentError, "session key must have length >= 32" unless key.size >= 32 %>

--- a/src/kibana-cf_authentication/index.js
+++ b/src/kibana-cf_authentication/index.js
@@ -81,6 +81,7 @@ module.exports = function (kibana) {
       var cfInfoUri = cloudFoundryApiUri + '/v2/info';
       var sessionExpirationMs = (process.env.SESSION_EXPIRATION_MS) ? process.env.SESSION_EXPIRATION_MS : 12 * 60 * 60 * 1000; // 12 hours by default
       var random_string = process.env.SESSION_KEY || randomstring.generate(40);
+      var skip_authorization = process.env.SKIP_AUTHORIZATION;
 
       if (skip_ssl_validation) {
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
@@ -112,6 +113,7 @@ module.exports = function (kibana) {
           redis_port: Joi.string().default(redis_port),
           session_expiration_ms: Joi.number().integer().default(sessionExpirationMs),
           use_https: Joi.boolean().default(useHttps)
+          skip_authorization: Joi.boolean().default(skip_authorization)
         }).default();
 
       }).catch(function (error) {
@@ -337,7 +339,7 @@ module.exports = function (kibana) {
                 if (err) {
                   server.log(['error', 'authentication', 'session:get:_filtered_msearch'], JSON.stringify(err));
                 }
-                if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1) {
+                if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1 && !(config.get('authentication.skip_authorization'))) {
                   var modified_payload = [];
                   var lines = request.payload.toString().split('\n');
                   var num_lines = lines.length;
@@ -383,7 +385,7 @@ module.exports = function (kibana) {
                 if (err) {
                   server.log(['error', 'authentication', 'session:get:_filtered_search'], JSON.stringify(err));
                 }
-                if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1) {
+                if (cached.account.orgs.indexOf(config.get('authentication.cf_system_org')) === -1 && !(config.get('authentication.skip_authorization')))  {
                   var payload = JSON.parse(request.payload.toString() || '{}');
                   payload = filterQuery(payload, cached);
                   options.payload = new Buffer(JSON.stringify(payload));


### PR DESCRIPTION
This PR will add a feature set through the variable `SKIP_AUTHORIZATION`. Setting this will allow any authenticated user to view all logs for all organizations in kibana.

For our use case, we want/need all developers to see logs across all organizations. This allows users to trace through requests as they traverse through the different microservices that are needed to process transactions. This provides visibility across the application but also provides a certain level of security in that all users accessing kibana are authenticated.   For coarse-grained authorization, an LDAP group can be used in the UAA integration to ensure only authorized users have access to logs.