### PR TITLE
Fix error after latest commit

### DIFF
--- a/src/kibana-cf_authentication/index.js
+++ b/src/kibana-cf_authentication/index.js
@@ -112,7 +112,7 @@ module.exports = function (kibana) {
           redis_host: Joi.string().default(redis_host),
           redis_port: Joi.string().default(redis_port),
           session_expiration_ms: Joi.number().integer().default(sessionExpirationMs),
-          use_https: Joi.boolean().default(useHttps)
+          use_https: Joi.boolean().default(useHttps),
           skip_authorization: Joi.boolean().default(skip_authorization)
         }).default();
 


### PR DESCRIPTION
This PR fixes a bug introduced in #272  resulting in a failure of kibana job to start and the following syslog:

\Plugin installation was unsuccessful due to error "/var/vcap/data/packages/kibana/916702f45cb2d55dc94f17134ddacd1c666925e9/plugins/authentication/index.js: Unexpected token, expected , (116:10)"