### PR TITLE
Replace alter.condrewriteother filter with alternative solution

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/setup.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/setup.conf
@@ -17,8 +17,10 @@ if [@message] =~ /^\s*$/ or [@message] =~ /^#.*$/ {
 mutate {
   add_field => { "@index_type" => "platform" } # by default logs go to 'platform'
 }
-alter {
-  condrewriteother => [ "syslog_program", "doppler", "@index_type", "app" ] # doppler logs go to 'app' index
+if [syslog_program] == "doppler" {
+  mutate {
+    update => { "@index_type" => "app" }
+  }
 }
 mutate {
   add_field => { "[@metadata][index]" => "%{@index_type}" }


### PR DESCRIPTION
We want to avoid installing a 3rd party filter plugin and the effect can be
easily achieved with built-in constructs.

Background: we are evaluating to use a 3rd party ELK stack and the alter filter plugin is not enabled there, but we would still like to use the Logstash filters from this project.