### PR TITLE
Replace alter.coalesce filter with alternative solution

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -90,8 +90,17 @@ if [@index_type] == "app" {
         }
 
         # Set @type (based on event_type)
-        alter {
-          coalesce => [ "@type", "%{[parsed_json_field][event_type]}", "UnknownEvent" ]
+        if [parsed_json_field][event_type] {
+          mutate {
+            add_field => { "@type" => "%{[parsed_json_field][event_type]}" }
+          }
+        } else {
+          mutate {
+            add_field => { "@type" => "UnknownEvent" }
+          }
+        }
+
+        mutate {
           remove_field => "[parsed_json_field][event_type]"
         }
 


### PR DESCRIPTION
We want to avoid installing a 3rd party filter plugin and the effect can be
easily achieved with built-in constructs.

Background: we are evaluating to use a 3rd party ELK stack and the alter filter plugin is not enabled there, but we would still like to use the Logstash filters from this project.