### PR TITLE
Add [rtr][response_time_ms] without using the ruby filter

### DIFF
--- a/src/logsearch-config/spec/logstash-filters/snippets/app_logmessage_rtr_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/app_logmessage_rtr_spec.rb
@@ -27,7 +27,7 @@ describe "app-logmessage-rtr.conf" do
         it { expect(parsed_results.get("tags")).to eq ["logmessage-rtr"] } # no fail tag
 
         # fields
-        it { expect(parsed_results.get("@message")).to eq "200 GET /some/http (5.329 ms)" }
+        it { expect(parsed_results.get("@message")).to eq "200 GET /some/http (5.328 ms)" }
         it { expect(parsed_results.get("@level")).to eq "INFO" }
 
         it "sets [rtr] fields" do
@@ -47,7 +47,7 @@ describe "app-logmessage-rtr.conf" do
           expect(parsed_results.get("rtr")["vcap_request_id"]).to eq "831e54f1-f09f-4971-6856-9fdd502d4ae3"
           # calculated values
           expect(parsed_results.get("rtr")["remote_addr"]).to eq "82.209.244.50"
-          expect(parsed_results.get("rtr")["response_time_ms"]).to eq 5.329
+          expect(parsed_results.get("rtr")["response_time_ms"]).to eq 5.328
         end
 
         it "sets geoip for [rtr][remote_addr]" do
@@ -73,7 +73,7 @@ describe "app-logmessage-rtr.conf" do
           it { expect(parsed_results.get("tags")).to eq ["logmessage-rtr"] } # no fail tag
 
           # fields
-          it { expect(parsed_results.get("@message")).to eq "200 GET /some/http (5.329 ms)" }
+          it { expect(parsed_results.get("@message")).to eq "200 GET /some/http (5.328 ms)" }
           it { expect(parsed_results.get("@level")).to eq "INFO" }
 
           it "sets [rtr] fields" do
@@ -93,7 +93,7 @@ describe "app-logmessage-rtr.conf" do
             expect(parsed_results.get("rtr")["vcap_request_id"]).to eq "831e54f1-f09f-4971-6856-9fdd502d4ae3"
             # calculated values
             expect(parsed_results.get("rtr")["remote_addr"]).to eq "82.209.244.50"
-            expect(parsed_results.get("rtr")["response_time_ms"]).to eq 5.329
+            expect(parsed_results.get("rtr")["response_time_ms"]).to eq 5.328
           end
 
           it "sets geoip for [rtr][remote_addr]" do
@@ -120,7 +120,7 @@ describe "app-logmessage-rtr.conf" do
           it { expect(parsed_results.get("tags")).to eq ["logmessage-rtr"] } # no fail tag
 
           # fields
-          it { expect(parsed_results.get("@message")).to eq "200 GET / (1.603 ms)" }
+          it { expect(parsed_results.get("@message")).to eq "200 GET / (1.602 ms)" }
           it { expect(parsed_results.get("@level")).to eq "INFO" }
 
           it "sets [rtr] fields" do
@@ -146,7 +146,7 @@ describe "app-logmessage-rtr.conf" do
             expect(parsed_results.get("rtr")["app"]["index"]).to eq 1
             # calculated values
             expect(parsed_results.get("rtr")["remote_addr"]).to eq "82.209.244.50"
-            expect(parsed_results.get("rtr")["response_time_ms"]).to eq 1.603
+            expect(parsed_results.get("rtr")["response_time_ms"]).to eq 1.602
           end
 
           it "sets geoip for [rtr][remote_addr]" do
@@ -352,6 +352,30 @@ describe "app-logmessage-rtr.conf" do
       end
     end
 
+  end
+
+  describe "when [rtr][response_time_sec] has only a few digits" do
+    when_parsing_log(
+        "@type" => "LogMessage",
+        "@source" => { "type" => "RTR" },
+        "@level" => "SOME LEVEL",
+        # rtr format
+        "@message" => "parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /some/http HTTP/1.1\" 200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" vcap_request_id:\"831e54f1-f09f-4971-6856-9fdd502d4ae3\" response_time:0.5 app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n"
+    ) do
+      it { expect(parsed_results.get("rtr")["response_time_ms"]).to eq 500 }
+    end
+  end
+
+  describe "when [rtr][response_time_sec] is an integer" do
+    when_parsing_log(
+        "@type" => "LogMessage",
+        "@source" => { "type" => "RTR" },
+        "@level" => "SOME LEVEL",
+        # rtr format
+        "@message" => "parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /some/http HTTP/1.1\" 200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" 192.168.111.21:35826 x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" vcap_request_id:\"831e54f1-f09f-4971-6856-9fdd502d4ae3\" response_time:5 app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n"
+    ) do
+      it { expect(parsed_results.get("rtr")["response_time_ms"]).to eq 5000 }
+    end
   end
 
 end

--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -43,17 +43,16 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
             }
         }
 
-
         # Set [rtr][response_time_ms]
-        ruby {
-           code => '
-             rtr = event.get("rtr")
-             rtr["response_time_ms"] = (rtr["response_time_sec"]*1000).round(3)
-             event.set("rtr", rtr) 
-           '
-           remove_field => "[rtr][response_time_sec]"
+        mutate {
+          add_field => { "[rtr][response_time_ms]" => "%{[rtr][response_time_sec]}000" }
         }
-
+        mutate {
+          gsub => ["[rtr][response_time_ms]", "\.(\d)(\d)(\d)([\d]{0,3}).*","\1\2\3.\4"]
+        }
+        mutate {
+          convert => { "[rtr][response_time_ms]" => "float" }
+        }
 
         # Set @message
         mutate {


### PR DESCRIPTION
We are evaluating to use a 3rd party ELK stack where the ruby filter plugin is not
enabled for security reasons, but we would still like to use the Logstash filters from this project.

This commit adds the response_time_ms using gsub. The value is truncated at three digits (instead of rounding).