### PR TITLE
Parse app log timestamp without using the ruby filter

### DIFF
--- a/src/logsearch-config/spec/logstash-filters/snippets/app_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/app_spec.rb
@@ -93,6 +93,8 @@ describe "app.conf" do
         it { expect(parsed_results.get("@index_type")).to eq "app" } # keeps unchanged
         it { expect(parsed_results.get("@metadata")["index"]).to eq "app-admin-demo" }
 
+        it { expect(parsed_results.get("@timestamp").to_i).to eq LogStash::Timestamp.at(1467972040).to_i }
+
       end
     end
 
@@ -122,6 +124,25 @@ describe "app.conf" do
   end
 
   # -- special cases
+
+  describe "sets the timestamp correctly" do
+    context "when start_timestamp is set" do
+      when_parsing_log( "@index_type" => "app",
+                        "@message" => "{\"start_timestamp\":1467972040073786262}"
+      ) do
+        it { expect(parsed_results.get("@timestamp").to_i).to eq LogStash::Timestamp.at(1467972040).to_i }
+      end
+    end
+
+    context "when both start_timestamp and timestamp are set it uses timestamp" do
+      when_parsing_log( "@index_type" => "app",
+                        "@message" => "{\"start_timestamp\":1467972040073786262,\"timestamp\":1467972050073786262}"
+      ) do
+        it { expect(parsed_results.get("@timestamp").to_i).to eq LogStash::Timestamp.at(1467972050).to_i }
+      end
+    end
+  end
+
   describe "mutates 'msg'" do
 
     context "when it contains unicode (null)" do

--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -35,19 +35,11 @@ if [@index_type] == "app" {
             mutate {
               rename => { "[parsed_json_field][start_timestamp]" => "event_timestamp" } # HttpStartStop event case
               rename => { "[parsed_json_field][timestamp]" => "event_timestamp" }
-            }
-            ruby {
-              # convert from nanosec-from-epoch number to Datetime
-              init => "require 'time'"
-              code => "
-                time_in_nanosec_from_epoch = event.get('event_timestamp')
-                time_in_seconds = time_in_nanosec_from_epoch / 10 ** 9
-                milliseconds = time_in_nanosec_from_epoch % 10 ** 9 / 1000.to_f
-                event.set('event_timestamp', Time.at(time_in_seconds, milliseconds).iso8601(6))
-              "
+              convert => { "event_timestamp" => "string" }
+              gsub => ["event_timestamp", "\d{6}$", ""]
             }
             date {
-              match => [ "event_timestamp", "ISO8601" ]
+              match => [ "event_timestamp", "UNIX_MS" ]
               remove_field => [ "event_timestamp" ]
             }
         } else if [parsed_json_field][time] {


### PR DESCRIPTION
We are evaluating to use a 3rd party ELK stack where the ruby filter plugin is not
enabled for security reasons, but we would still like to use the Logstash filters from this project.