### PR TITLE
Replace "vcap." in [@source][component] without using the ruby filter

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/platform-vcap.conf
@@ -3,12 +3,11 @@
 ##-----------------------------
 if [@source][component] != "vcap.uaa" and [@source][component] =~ /vcap\..*/ {
 
-    ruby {
-      code => '
-        component_name = event.get("[@source][component]")[5..-1]
-        event.set("[@source][component]", component_name)
-      ' # minus vcap. prefix
+    # minus vcap. prefix
+    mutate {
+      gsub => ["[@source][component]", "^vcap\.", ""]
     }
+
     mutate {
       replace => { "@type" => "vcap" }
       add_tag => "vcap"


### PR DESCRIPTION
We are evaluating to use a 3rd party ELK stack where the ruby filter plugin is not
enabled for security reasons, but we would still like to use the Logstash filters from this project.