### PR TITLE
Set parsed json field without using the ruby filter

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -46,12 +46,8 @@ if [parsed_json_field] and [parsed_json_field_name] {
       lowercase => [ "parsed_json_field_name" ]
       gsub => [ "parsed_json_field_name", "[\s/\\?#-\.]", "_" ]
     }
-    ruby {
-      code => '
-        field_name = event.get("parsed_json_field_name").to_s.downcase
-        field_content = event.get("parsed_json_field")
-        event.set(field_name, LogStash::Util.normalize(field_content))
-      '
+    mutate {
+      add_field => { "%{parsed_json_field_name}" => "%{parsed_json_field}" }
       remove_field => [ "parsed_json_field" ]
     }
 }
@@ -63,7 +59,7 @@ mutate {
 # -- Cleanup unnecessary fields
 
 # Remove syslog_ fields
-mutate {      
+mutate {
   remove_field => "syslog_pri"
   remove_field => "syslog_facility"
   remove_field => "syslog_facility_code"


### PR DESCRIPTION
We are evaluating to use a 3rd party ELK stack where the ruby filter plugin is not
enabled for security reasons, but we would still like to use the Logstash filters from this project.

This change removes the LogStash::Util.normalize which might not be necessary
at all, but we don't understand its purpose and there are no tests for it.

If the LogStash::Util.normalize() is necessary could you please help to shine some light on its purpose?