### PR TITLE
Fix integration tests and revert bad changes

### DIFF
--- a/src/logsearch-config/spec/logstash-filters/integration/app_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/integration/app_spec.rb
@@ -98,7 +98,7 @@ describe "App IT" do
 
         verify_app_general_fields("app-admin-demo", "LogMessage", "RTR",
                                   # RTR message
-                                  '200 GET / (1.603 ms)', "INFO")
+                                  '200 GET / (1.602 ms)', "INFO")
 
         verify_app_cf_fields(99)
 
@@ -131,7 +131,7 @@ describe "App IT" do
           expect(parsed_results.get("rtr")["app"]["index"]).to eq 1
           # calculated values
           expect(parsed_results.get("rtr")["remote_addr"]).to eq "82.209.244.50"
-          expect(parsed_results.get("rtr")["response_time_ms"]).to eq 1.603
+          expect(parsed_results.get("rtr")["response_time_ms"]).to eq 1.602
         end
 
         it "sets geoip for [rtr][remote_addr]" do

--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -82,17 +82,8 @@ if [@index_type] == "app" {
         }
 
         # Set @type (based on event_type)
-        if [parsed_json_field][event_type] {
-          mutate {
-            add_field => { "@type" => "%{[parsed_json_field][event_type]}" }
-          }
-        } else {
-          mutate {
-            add_field => { "@type" => "UnknownEvent" }
-          }
-        }
-
-        mutate {
+        alter {
+          coalesce => [ "@type", "%{[parsed_json_field][event_type]}", "UnknownEvent" ]
           remove_field => "[parsed_json_field][event_type]"
         }
 

--- a/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/teardown.conf
@@ -47,8 +47,7 @@ if [parsed_json_field] and [parsed_json_field_name] {
       gsub => [ "parsed_json_field_name", "[\s/\\?#-\.]", "_" ]
     }
     mutate {
-      add_field => { "%{parsed_json_field_name}" => "%{parsed_json_field}" }
-      remove_field => [ "parsed_json_field" ]
+      rename => { "parsed_json_field" => "%{parsed_json_field_name}" }
     }
 }
 


### PR DESCRIPTION
Previously I submitted 6 PRs which were all merged without a question, but as it turns out the automated tests weren't running for these PRs and you merged them without knowing that these broke the integration tests.

We only ran the unit tests before submitting the PRs.

This PR:
 - reverts #286 (alter.coalesce is better to use there, it seems that one is not so trivial to replace)
 - fixes the integration tests for #287
 - fixes #290 which broke the JSON parsing for some fields