### PR TITLE
Update path in description for logstash_parser.custom_filters property

### DIFF
--- a/jobs/parser-config-lfc/spec
+++ b/jobs/parser-config-lfc/spec
@@ -27,5 +27,5 @@ properties:
   logstash_parser.custom_filters:
     description: |
       Custom logstash filters that will be appended to the logstash filters list.
-      Populates the file /var/vcap/jobs/logsearch-for-cloudfoundry-filters/config/logstash-filters-custom.conf
+      Populates the file /var/vcap/jobs/parser-config-lfc/config/logstash-filters-custom.conf
     default: ""


### PR DESCRIPTION
The path in the description for logstash_parser.custom_filters references a job that does not exist.