### PR TITLE
Replace alter filter when processing app logs

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app.conf
@@ -81,10 +81,15 @@ if [@index_type] == "app" {
           rename => { "[parsed_json_field][origin]"      => "[@source][component]" }
         }
 
+        if ![parsed_json_field][event_type] {
+          mutate {
+            add_field => { "[parsed_json_field][event_type]" => "UnknownEvent" }
+          }
+        }
+
         # Set @type (based on event_type)
-        alter {
-          coalesce => [ "@type", "%{[parsed_json_field][event_type]}", "UnknownEvent" ]
-          remove_field => "[parsed_json_field][event_type]"
+        mutate {
+          replace => { "@type" => "%{[parsed_json_field][event_type]}" }
         }
 
         # Set [@source][type] (based on @type by default,


### PR DESCRIPTION
We want to avoid installing a 3rd party filter plugin and the effect can be
easily achieved with built-in constructs.

Background: we are evaluating to use a 3rd party ELK stack and the alter filter plugin is not enabled there, but we would still like to use the Logstash filters from this project.