### PR TITLE
allow overwriting the elasticsearch host and port

### DIFF
--- a/jobs/cf-kibana/templates/allow-logsearch-access.json.erb
+++ b/jobs/cf-kibana/templates/allow-logsearch-access.json.erb
@@ -1,15 +1,16 @@
 <%
   elasticsearch_host = nil
   elasticsearch_port = nil
-  if_link("elasticsearch") { |elasticsearch_link|
-    elasticsearch_host = elasticsearch_link.instances.first.address
-    elasticsearch_port = elasticsearch_link.p("elasticsearch.port")
-  }
-  unless elasticsearch_host
-    elasticsearch_host = p("cf-kibana.elasticsearch.host")
+  if_p('cf-kibana.elasticsearch.host') do |prop|
+    elasticsearch_host = prop
+  end.else do
+    elasticsearch_host = link('elasticsearch').instances.first.address
   end
-  unless elasticsearch_port
-    elasticsearch_port = p("cf-kibana.elasticsearch.port")
+
+  if_p('cf-kibana.elasticsearch.port') do |prop|
+    elasticsearch_port = prop
+  end.else do
+    elasticsearch_port = link('elasticsearch').p("elasticsearch.port")
   end
 
   redis_host = nil

--- a/jobs/cf-kibana/templates/kibana.yml.erb
+++ b/jobs/cf-kibana/templates/kibana.yml.erb
@@ -14,15 +14,17 @@ server.host: "0.0.0.0"
 # The URL of the Elasticsearch instance to use for all your queries.
 <%
   elasticsearch_host = nil
-  if_link("elasticsearch") { |elasticsearch_link| elasticsearch_host = elasticsearch_link.instances.first.address }
-  unless elasticsearch_host
-    elasticsearch_host = p("cf-kibana.elasticsearch.host")
+  if_p('cf-kibana.elasticsearch.host') do |prop|
+    elasticsearch_host = prop
+  end.else do
+    elasticsearch_host = link('elasticsearch').instances.first.address
   end
 
   elasticsearch_port = nil
-  if_link("elasticsearch") { |elasticsearch_link| elasticsearch_port = elasticsearch_link.p("elasticsearch.port") }
-  unless elasticsearch_port
-    elasticsearch_port = p("cf-kibana.elasticsearch.port")
+  if_p('cf-kibana.elasticsearch.port') do |prop|
+    elasticsearch_port = prop
+  end.else do
+    elasticsearch_port = link('elasticsearch').p("elasticsearch.port")
   end
 %>
 elasticsearch.url: "http://<%= elasticsearch_host + ':' + elasticsearch_port.to_s %>"


### PR DESCRIPTION
This will allow the overwriting of the elasticsearch host and port properties for the cf-kibana job if specified in the deployment manifest.
The job will use the link if the properties is not specified as is the case now.

Example: a deployment can specify a DNS CNAME that points to all elasticsearch host and oprator can use this CNAME for the cf-kibana.elasticsearch.host property