### PR TITLE
RTR response status code mapping to log level

### DIFF
--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -59,11 +59,14 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
           replace => {"@message" => "%{[rtr][status]} %{[rtr][verb]} %{[rtr][path]} (%{[rtr][response_time_ms]} ms)"}
         }
 
-
         # Set @level (based on HTTP status)
-        if [rtr][status] >= 400 {
+        if [rtr][status] >= 500 {
             mutate {
               replace => { "@level" => "ERROR" }
+            }
+        } else if [rtr][status] >= 400 {
+            mutate {
+              replace => { "@level" => "WARN" }
             }
         } else {
             mutate {


### PR DESCRIPTION
## AS IS
All responses code >= `400` are mapped to `ERROR` log level, which is misleading for me.
Even if RTR event is like this: 
`"level":"info","message_type":"OUT", "msg":"my.domain.com - [2019-04-01T14:28:39.243+0000] \"GET /wrongurl HTTP/1.1\" 404`

## TO BE
The new mapping:
- `5xx` - `ERROR`
- `4xx` - `WARN`
- others - `INFO`