### PR TITLE
Ensure that upload-kibana-objects trusts system CA certs

### DIFF
--- a/jobs/upload-kibana-objects/templates/bin/run
+++ b/jobs/upload-kibana-objects/templates/bin/run
@@ -7,6 +7,7 @@ source /var/vcap/packages/ruby-2.4-r5/bosh/runtime.env
 export PATH=/var/vcap/packages/python3/bin:$PATH
 export PYTHONPATH="/var/vcap/packages/python3/lib/python3.6/site-packages${PYTHONPATH:+:$PYTHONPATH}"
 export LD_LIBRARY_PATH="/var/vcap/packages/python3/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export REQUESTS_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
 
 <%
   system_domain = nil


### PR DESCRIPTION
Hi logsearch-for-cloudfoundry team,

By default the python3 requests library does not trust the system CA certs. It is quite common to have custom certificates on the Cloud Foundry routers which are signed by local CA certificates that are installed on each bosh-deployed VM (for example via [ca_certs](https://bosh.io/jobs/ca_certs?source=github.com/cloudfoundry/os-conf-release&version=20.0.0) job or when [configuring](https://bosh.io/jobs/director?source=github.com/cloudfoundry/bosh&version=269.0.0#p%3ddirector.trusted_certs) the director). 

This fixes an issue where the upload-kibana-objects errand fails because the python3 requests library does not load custom CAs that have been installed as system root certificates, and therefore gets an `[SSL: CERTIFICATE_VERIFY_FAILED]` error when attempting to make requests to the CF API.

I have verified that this works by updating the script and running `/var/vcap/jobs/upload-kibana-objects/bin/run` successfully.

kind regards,

Pete