### PR TITLE
Remove assertion in upload-kibana-objects that fails when using OAuth to authenticate Kibana fixes #320

### DIFF
--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -22,7 +22,7 @@ if __name__ == "__main__":
             'X-Uaa-Csrf': logs.cookies['X-Uaa-Csrf'],
         },
     )
-    assert login.url == 'https://logs.{}/'.format(os.environ['CF_SYSTEM_DOMAIN'])
+
     assert login.status_code == 200
 
     for filename in glob.iglob('/var/vcap/jobs/upload-kibana-objects/kibana-objects/**/*.json', recursive=True):


### PR DESCRIPTION
The next assertion still checks the response is 200 which should still provide a reasonable level of security. 

I've verified that this code works by manually updating `/var/vcap/jobs/upload-kibana-objects/bin/import-objects` and then triggering the errand via `/var/vcap/jobs/upload-kibana-objects/bin/run`  and verifying that the errand completes successfully.

Fixes #320 