### PR TITLE
don't assume logs and login FQDNs

### DIFF
--- a/jobs/upload-kibana-objects/spec
+++ b/jobs/upload-kibana-objects/spec
@@ -118,7 +118,7 @@ properties:
   kibana_objects.login_host_name:
     description: the host-portion of the login FQDN, without the domain name
     default: login
-  kibana_objects.fqdn:
+  kibana_objects.login_fqdn:
     description: the fqdn of the login endpoint. If empty, kibana.log_host_name + . + cloudfoundry.system_domain is used 
 
   elasticsearch.host:

--- a/jobs/upload-kibana-objects/spec
+++ b/jobs/upload-kibana-objects/spec
@@ -112,6 +112,12 @@ properties:
   kibana_objects.default_index:
     description: "Default index to set in Kibana"
     default: "logs-app*"
+  kibana_objects.host_name:
+    description: the host-portion of the FQDN kibana is served from, without the domain name
+    default: logs
+  kibana_objects.login_host_name:
+    description: the host-portion of the login FQDN, without the domain name
+    default: login
 
   elasticsearch.host:
     description: Elasticsearch host

--- a/jobs/upload-kibana-objects/spec
+++ b/jobs/upload-kibana-objects/spec
@@ -118,6 +118,8 @@ properties:
   kibana_objects.login_host_name:
     description: the host-portion of the login FQDN, without the domain name
     default: login
+  kibana_objects.fqdn:
+    description: the fqdn of the login endpoint. If empty, kibana.log_host_name + . + cloudfoundry.system_domain is used 
 
   elasticsearch.host:
     description: Elasticsearch host

--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     assert logs.status_code == 200
 
     login = session.post(
-        'https://<%= p("kibana_objects.login_host_name") %>.<%= system_domain %>/login.do',
+        'https://<%= login_fqdn  %>/login.do',
         data={
             'username': '<%= p('cloudfoundry.user') %>',
             'password': '<%= p('cloudfoundry.password') %>',

--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -19,31 +19,31 @@ logging.basicConfig(level=logging.INFO)
 if __name__ == "__main__":
     session = requests.Session()
 
-    logs = session.get('https://<=% kibana_objects.host_name %>.<%= system_domain %>'<% if p("cloudfoundry.skip_ssl_validation") %>, verify=False<% end %>)
-    assert logs.url == 'https://<=% kibana_objects.login_host_name %>.<%= system_domain %>/login'
+    logs = session.get('https://<%= p("kibana_objects.host_name") %>.<%= system_domain %>'<% if p("cloudfoundry.skip_ssl_validation") %>, verify=False<% end %>)
+    assert logs.url == 'https://<%= p("kibana_objects.login_host_name") %>.<%= system_domain %>/login'
     assert logs.status_code == 200
 
     login = session.post(
-        'https://<=% kibana_objects.login_host_name %>.<%= system_domain %>/login.do',
+        'https://<%= p("kibana_objects.login_host_name") %>.<%= system_domain %>/login.do',
         data={
             'username': '<%= p('cloudfoundry.user') %>',
             'password': '<%= p('cloudfoundry.password') %>',
             'X-Uaa-Csrf': logs.cookies['X-Uaa-Csrf'],
         },
     )
-    assert login.url == 'https://<=% kibana_objects.host_name %>.<%= system_domain %>/app/kibana'
+    assert login.url == 'https://<%= p("kibana_objects.host_name") %>.<%= system_domain %>/app/kibana'
     assert login.status_code == 200
 
     for filename in glob.iglob('/var/vcap/jobs/upload-kibana-objects/kibana-objects/**/*.json', recursive=True):
         headers = {'content-type': 'application/json', 'kbn-xsrf': 'true'}
         r = session.post(
-                'https://<=% kibana_objects.host_name %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
+                'https://<%= p("kibana_objects.host_name") %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
                 data=open(filename, 'rb'),
                 headers=headers
         )
         if r.status_code == 409:
             put = session.put(
-                    'https://<=% kibana_objects.host_name %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
+                    'https://<%= p("kibana_objects.host_name") %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
                     data=open(filename, 'rb'),
                     headers=headers
             )
@@ -57,7 +57,7 @@ if __name__ == "__main__":
             logging.info('Object %s Failed to Upload', filename)
 
     r = session.post(
-      'https://<=% kibana_objects.host_name %>.<%= system_domain %>/api/kibana/settings',
+      'https://<%= p("kibana_objects.host_name") %>.<%= system_domain %>/api/kibana/settings',
       data='{"changes":{"defaultIndex":"<%= p('kibana_objects.default_index') %>"}}',
       headers=headers
     )

--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -19,31 +19,31 @@ logging.basicConfig(level=logging.INFO)
 if __name__ == "__main__":
     session = requests.Session()
 
-    logs = session.get('https://logs.<%= system_domain %>'<% if p("cloudfoundry.skip_ssl_validation") %>, verify=False<% end %>)
-    assert logs.url == 'https://login.<%= system_domain %>/login'
+    logs = session.get('https://<=% kibana_objects.host_name %>.<%= system_domain %>'<% if p("cloudfoundry.skip_ssl_validation") %>, verify=False<% end %>)
+    assert logs.url == 'https://<=% kibana_objects.login_host_name %>.<%= system_domain %>/login'
     assert logs.status_code == 200
 
     login = session.post(
-        'https://login.<%= system_domain %>/login.do',
+        'https://<=% kibana_objects.login_host_name %>.<%= system_domain %>/login.do',
         data={
             'username': '<%= p('cloudfoundry.user') %>',
             'password': '<%= p('cloudfoundry.password') %>',
             'X-Uaa-Csrf': logs.cookies['X-Uaa-Csrf'],
         },
     )
-    assert login.url == 'https://logs.<%= system_domain %>/app/kibana'
+    assert login.url == 'https://<=% kibana_objects.host_name %>.<%= system_domain %>/app/kibana'
     assert login.status_code == 200
 
     for filename in glob.iglob('/var/vcap/jobs/upload-kibana-objects/kibana-objects/**/*.json', recursive=True):
         headers = {'content-type': 'application/json', 'kbn-xsrf': 'true'}
         r = session.post(
-                'https://logs.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
+                'https://<=% kibana_objects.host_name %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
                 data=open(filename, 'rb'),
                 headers=headers
         )
         if r.status_code == 409:
             put = session.put(
-                    'https://logs.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
+                    'https://<=% kibana_objects.host_name %>.<%= system_domain %>/api/saved_objects/{}/{}'.format(os.path.basename(os.path.dirname(filename)), os.path.basename(os.path.splitext(filename)[0])),
                     data=open(filename, 'rb'),
                     headers=headers
             )
@@ -57,7 +57,7 @@ if __name__ == "__main__":
             logging.info('Object %s Failed to Upload', filename)
 
     r = session.post(
-      'https://logs.<%= system_domain %>/api/kibana/settings',
+      'https://<=% kibana_objects.host_name %>.<%= system_domain %>/api/kibana/settings',
       data='{"changes":{"defaultIndex":"<%= p('kibana_objects.default_index') %>"}}',
       headers=headers
     )

--- a/jobs/upload-kibana-objects/templates/bin/import-objects
+++ b/jobs/upload-kibana-objects/templates/bin/import-objects
@@ -9,6 +9,15 @@
   end
 %>
 
+<% 
+  login_fqdn = nil
+  if_p('kibana_objects.login_fqdn') do |prop|
+    login_fqdn = prop
+  end.else do
+    login_fqdn = [p("kibana_objects.login_host_name"), system_domain].join('.')
+  end
+%>
+
 import glob
 import logging
 import os
@@ -20,7 +29,7 @@ if __name__ == "__main__":
     session = requests.Session()
 
     logs = session.get('https://<%= p("kibana_objects.host_name") %>.<%= system_domain %>'<% if p("cloudfoundry.skip_ssl_validation") %>, verify=False<% end %>)
-    assert logs.url == 'https://<%= p("kibana_objects.login_host_name") %>.<%= system_domain %>/login'
+    assert logs.url == 'https://<%= login_fqdn %>/login'
     assert logs.status_code == 200
 
     login = session.post(


### PR DESCRIPTION
fixes #331 

Currently, upload_kibana_objects assumes kibana is at `logs.<system_domain>` and that login is at `login.<system_domain>/login`
As far as I can tell, this is the only place that assumption is made, and the assumption is not stated as a requirement. This allows users to have alternate hostnames for kibana and login to kibana, while retaining the ability to use upload_kibana_objects