### PR TITLE
Add a logmessage_rtr config for new gorouter_time and app_time fields

### DIFF
--- a/src/logsearch-config/spec/logstash-filters/snippets/app_logmessage_rtr_spec.rb
+++ b/src/logsearch-config/spec/logstash-filters/snippets/app_logmessage_rtr_spec.rb
@@ -174,6 +174,77 @@ describe "app-logmessage-rtr.conf" do
 
     end
 
+    context "RTR format (cf-deployment v12.17.0+)" do
+
+      context "" do
+        when_parsing_log(
+            "@type" => "LogMessage",
+            "@source" => { "type" => "RTR" },
+            "@level" => "SOME LEVEL",
+            # rtr format - quoted requestRemoteAddr and destIPandPort
+            "@message" => "parser.64.78.234.207.xip.io - [2017-03-16T13:28:25.166+0000] \"GET / HTTP/1.1\" 200 0 1677 \"-\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36\" \"10.2.9.104:60079\" \"10.2.32.71:61010\" x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"https\" vcap_request_id:\"f322dd76-aacf-422e-49fb-c73bc46ce45b\" response_time:0.001602684 gorouter_time:0.000163 app_time:0.024988 app_id:\"27c02dec-80ce-4af6-94c5-2b51848edae9\" app_index:\"1\"\n"
+        ) do
+
+          # no parsing errors
+          it { expect(parsed_results.get("tags")).to eq ["logmessage-rtr"] } # no fail tag
+
+          # fields
+          it { expect(parsed_results.get("@message")).to eq "200 GET / (1.602 ms)" }
+          it { expect(parsed_results.get("@level")).to eq "INFO" }
+
+          it "sets [rtr] fields" do
+            expect(parsed_results.get("rtr")["hostname"]).to eq "parser.64.78.234.207.xip.io"
+            expect(parsed_results.get("rtr")["timestamp"]).to eq "2017-03-16T13:28:25.166+0000"
+            expect(parsed_results.get("rtr_time")).to be_nil
+            expect(parsed_results.get("rtr")["verb"]).to eq "GET"
+            expect(parsed_results.get("rtr")["path"]).to eq "/"
+            expect(parsed_results.get("rtr")["http_spec"]).to eq "HTTP/1.1"
+            expect(parsed_results.get("rtr")["status"]).to eq 200
+            expect(parsed_results.get("rtr")["request_bytes_received"]).to eq 0
+            expect(parsed_results.get("rtr")["body_bytes_sent"]).to eq 1677
+            expect(parsed_results.get("rtr")["referer"]).to eq "-"
+            expect(parsed_results.get("rtr")["http_user_agent"]).to eq "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36"
+            expect(parsed_results.get("rtr")["x_forwarded_for"]).to eq ["82.209.244.50", "192.168.111.21"]
+            expect(parsed_results.get("rtr")["x_forwarded_proto"]).to eq "https"
+            expect(parsed_results.get("rtr")["vcap_request_id"]).to eq "f322dd76-aacf-422e-49fb-c73bc46ce45b"
+            expect(parsed_results.get("rtr")["src"]["host"]).to eq "10.2.9.104"
+            expect(parsed_results.get("rtr")["src"]["port"]).to eq 60079
+            expect(parsed_results.get("rtr")["dst"]["host"]).to eq "10.2.32.71"
+            expect(parsed_results.get("rtr")["dst"]["port"]).to eq 61010
+            expect(parsed_results.get("rtr")["app"]["id"]).to eq "27c02dec-80ce-4af6-94c5-2b51848edae9"
+            expect(parsed_results.get("rtr")["app"]["index"]).to eq 1
+            # calculated values
+            expect(parsed_results.get("rtr")["remote_addr"]).to eq "82.209.244.50"
+            expect(parsed_results.get("rtr")["response_time_ms"]).to eq 1.602
+            expect(parsed_results.get("rtr")["gorouter_time_ms"]).to_eq 0.000163
+            expect(parsed_results.get("rtr")["app_time_ms"]).to_eq 0.024988
+          end
+
+          it "sets geoip for [rtr][remote_addr]" do
+            expect(parsed_results.get("geoip")).not_to be_nil
+            expect(parsed_results.get("geoip")["ip"]).to eq "82.209.244.50"
+          end
+
+        end
+      end
+
+      context "empty requestRemoteAddr and destIPandPort" do
+        when_parsing_log(
+            "@type" => "LogMessage",
+            "@source" => { "type" => "RTR" },
+            "@level" => "SOME LEVEL",
+            # rtr format - quoted requestRemoteAddr and destIPandPort
+            "@message" => "parser.64.78.234.207.xip.io - [15/07/2016:09:26:25 +0000] \"GET /some/http HTTP/1.1\" 200 0 1413 \"-\" \"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\" \"-\" \"-\" x_forwarded_for:\"82.209.244.50, 192.168.111.21\" x_forwarded_proto:\"http\" vcap_request_id:\"831e54f1-f09f-4971-6856-9fdd502d4ae3\" response_time:0.005328859 app_id:7ae227a6-6ad1-46d4-bfb9-6e60d7796bb5\n"
+        ) do
+
+          # no parsing errors
+          it { expect(parsed_results.get("tags")).to eq ["logmessage-rtr"] } # no fail tag
+
+        end
+      end
+
+    end
+
     context "bad format" do
       when_parsing_log(
           "@type" => "LogMessage",

--- a/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
+++ b/src/logsearch-config/src/logstash-filters/snippets/app-logmessage-rtr.conf
@@ -17,6 +17,9 @@ if ( [@type] == "LogMessage" and [@source][type] == "RTR" ) {
       # cf-release v252+
       match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"(%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}|-)\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"(%{BASE10NUM:[rtr][app][index]:int}|-)\""]
 
+      # cf-deployment v12.17.0+
+      match => [ "@message", "%{HOSTNAME:[rtr][hostname]} - \[(?<rtr_time>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}T%{TIME}+%{INT})\] \"%{WORD:[rtr][verb]} %{URIPATHPARAM:[rtr][path]} %{PROG:[rtr][http_spec]}\" %{BASE10NUM:[rtr][status]:int} %{BASE10NUM:[rtr][request_bytes_received]:int} %{BASE10NUM:[rtr][body_bytes_sent]:int} \"%{GREEDYDATA:[rtr][referer]}\" \"%{GREEDYDATA:[rtr][http_user_agent]}\" \"%{IPORHOST:[rtr][src][host]}:%{POSINT:[rtr][src][port]:int}\" \"%{IPORHOST:[rtr][dst][host]}:%{POSINT:[rtr][dst][port]:int}\" x_forwarded_for:\"%{GREEDYDATA:[rtr][x_forwarded_for]}\" x_forwarded_proto:\"%{GREEDYDATA:[rtr][x_forwarded_proto]}\" vcap_request_id:\"%{NOTSPACE:[rtr][vcap_request_id]}\" response_time:%{NUMBER:[rtr][response_time_sec]:float} gorouter_time:%{NUMBER:[rtr][gorouter_time_sec]:float} app_time:%{NUMBER:[rtr][app_time_sec]:float} app_id:\"%{NOTSPACE:[rtr][app][id]}\" app_index:\"%{BASE10NUM:[rtr][app][index]:int}\""]
+
       tag_on_failure => [ "fail/cloudfoundry/app-rtr/grok" ]
     }
 


### PR DESCRIPTION
These [gorouter_time and app_time fields](https://www.pivotaltracker.com/n/projects/2245594/stories/169491715) were introduced in [routing-release 0.196.0](https://github.com/cloudfoundry/routing-release/releases/tag/0.196.0) which forms part of [cf-deployment v12.17.0](https://github.com/cloudfoundry/cf-deployment/releases/tag/v12.17.0) 