### PR TITLE
Make auth plugin work

### DIFF
--- a/src/kibana-cf_authentication/server/routes.js
+++ b/src/kibana-cf_authentication/server/routes.js
@@ -72,6 +72,7 @@ module.exports = (server, config, cache) => {
         payload: {
           parse: false
         },
+        validate: { payload: null },
         handler: async (request, h) => {
           const options = {
             method: 'POST',
@@ -128,6 +129,7 @@ module.exports = (server, config, cache) => {
         payload: {
           parse: false
         },
+        validate: { payload: null },
         handler: async (request, h) => {
           const options = {
             method: 'POST',


### PR DESCRIPTION
In Kibana 7.6, the plugin stopped working due to a complaint about payload validation. Adding these two lines retains the same functionality before, but makes the plugin work in Kibana 7.6 or above.