### PR TITLE
kibana.plugin cf-authentication update

### DIFF
--- a/src/kibana-cf_authentication/server/config.js
+++ b/src/kibana-cf_authentication/server/config.js
@@ -79,10 +79,13 @@ module.exports = async (Joi) => {
 
     return result
   } catch (error) {
-    console.error(`config.ERROR fetching CF info from "${cfInfoUri}`, error)
+    let message = `config.ERROR fetching CF info from "${cfInfoUri}". `;
 
-    return Joi.object({
-      enabled: Joi.boolean().default(true)
-    }).default()
+    message +=
+      error.message === "self signed certificate"
+        ? "Self signed certificate detected. Please set kibana-auth.cloudfoundry.skip_ssl_validation=true in kibana-auth-plugin.yml if this is desired behavior"
+        : error.message;
+
+    throw new Error(message);
   }
 }


### PR DESCRIPTION
added self signed certificate handling, so that plugin will crash unless `kibana-auth.cloudfoundry.skip_ssl_validation` is set to true.

Plugin will also crash in case we didn't manage to  obtain valid configuration.