### PR TITLE
Fix Kibana Auth Plugin issue: authentication is disabled when SSL validation is enabled!

### DIFF
--- a/jobs/kibana-auth-plugin/templates/config/config.sh.erb
+++ b/jobs/kibana-auth-plugin/templates/config/config.sh.erb
@@ -34,6 +34,10 @@ export REDIS_PORT="<%= redis_port %>"
 export KIBANA_DOMAIN="<%= p("kibana-auth.app_name") %>.<%= system_domain %>"
 export SKIP_AUTHORIZATION="<%= p("kibana-auth.skip_authorization") %>"
 
+if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+  export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+fi
+
 <% if_p("kibana-auth.session_key") do |key| %>
 <% raise ArgumentError, "session key must have length >= 32" unless key.size >= 32 %>
 export SESSION_KEY="<%= key %>"


### PR DESCRIPTION
The Kibana auth plugin does not currently trust system certificates by default. When `kibana-auth.cloudfoundry.skip_ssl_validation` is false, the Kibana auth plugin fails to load and Kibana ignores failed plugins and then continues to load without authentication! The Kibana stderr logs indicate that the plugin fails to load due to a certificate error:

```
==> /var/vcap/sys/log/kibana/kibana.stderr.log <==
config.ERROR fetching CF info from "https://<SYSTEM_DOMAIN>/v2/info { Error: unable to get local issuer certificate
    at TLSSocket.onConnectSecure (_tls_wrap.js:1058:34)
    at TLSSocket.emit (events.js:198:13)
    at TLSSocket._finishInit (_tls_wrap.js:636:8) code: 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY' }
```

This fix sets NODE_EXTRA_CA_CERTS to the system certificate bundle for Ubuntu if this file exists, which allows the Kibana auth plugin to load successfully, and therefore enabling authentication for Kibana. 

We have tested this script by manually editing config.sh on a running instance and verifying that it fixes the issue.